### PR TITLE
Port iomux to imxrt-ral

### DIFF
--- a/imxrt-hal/Cargo.toml
+++ b/imxrt-hal/Cargo.toml
@@ -26,15 +26,17 @@ test = false
 
 [features]
 default = ["embedded-hal/unproven"] # Allows us to access the new digital pin traits
+
+# Device specific feature flags
 # these need fixes and conditional sections in CCM
 #imxrt1011 = ["imxrt-ral/imxrt1011"]
 #imxrt1015 = ["imxrt-ral/imxrt1015"]
 #imxrt1021 = ["imxrt-ral/imxrt1021"]
-imxrt1051 = ["imxrt-ral/imxrt1051"]
-imxrt1052 = ["imxrt-ral/imxrt1052"]
-imxrt1061 = ["imxrt-ral/imxrt1061"]
+#imxrt1051 = ["imxrt-ral/imxrt1051"]
+#imxrt1052 = ["imxrt-ral/imxrt1052"]
+#imxrt1061 = ["imxrt-ral/imxrt1061"]
 imxrt1062 = ["imxrt-ral/imxrt1062"]
-imxrt1064 = ["imxrt-ral/imxrt1064"]
+#imxrt1064 = ["imxrt-ral/imxrt1064"]
 rtfm = ["imxrt-ral/rtfm"]
 rt = ["imxrt-ral/rt"]
 nosync = ["imxrt-ral/nosync"]

--- a/imxrt-hal/src/ccm.rs
+++ b/imxrt-hal/src/ccm.rs
@@ -6,7 +6,6 @@ use arm_clock::set_arm_clock;
 use core::time::Duration;
 use imxrt_ral as ral;
 
-
 pub struct Handle {
     pub(crate) base: ral::ccm::Instance,
     pub(crate) analog: ral::ccm_analog::Instance,
@@ -39,14 +38,12 @@ impl PLL1 {
     fn new() -> Self {
         PLL1(())
     }
-    
+
     #[cfg(any(feature = "imxrt1011", feature = "imxrt1015"))]
     pub const ARM_HZ: u32 = 500_000_000;
 
     #[cfg(any(feature = "imxrt1064", feature = "imxrt1062", feature = "imxrt1061"))]
     pub const ARM_HZ: u32 = 600_000_000;
-
-
 
     /// Set the clock speed for the ARM core. This represents the base processor frequency.
     /// Consider using the 600MHz recommended frequency `PLL1::ARM_HZ`.
@@ -81,8 +78,7 @@ impl CCM {
 pub mod perclk {
     use super::{ral, Divider, Frequency, Handle, OSCILLATOR_FREQUENCY};
 
-    use ral::{modify_reg, ccm::CSCMR1::PERCLK_CLK_SEL};
-
+    use ral::{ccm::CSCMR1::PERCLK_CLK_SEL, modify_reg};
 
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
     pub enum CLKSEL {
@@ -147,8 +143,6 @@ pub mod perclk {
     }
 }
 
-
-
 macro_rules! pfd {
     ($setter:ident, $value:ident) => {
         use super::Handle;
@@ -168,27 +162,32 @@ macro_rules! pfd {
             }
 
             pub fn set(&mut self, handle: &mut Handle, pfds: [Option<Frequency>; 4]) {
-
                 let (pfd0_clkgate, pfd0_frac) = pfd_gate_frac(&pfds[0]);
                 let (pfd1_clkgate, pfd1_frac) = pfd_gate_frac(&pfds[1]);
                 let (pfd2_clkgate, pfd2_frac) = pfd_gate_frac(&pfds[2]);
                 let (pfd3_clkgate, pfd3_frac) = pfd_gate_frac(&pfds[3]);
 
-                write_reg!(ral::ccm_analog, handle.analog, $setter,
-                           PFD0_CLKGATE: pfd0_clkgate,
-                           PFD1_CLKGATE: pfd1_clkgate,
-                           PFD2_CLKGATE: pfd2_clkgate,
-                           PFD3_CLKGATE: pfd3_clkgate
+                write_reg!(
+                    ral::ccm_analog,
+                    handle.analog,
+                    $setter,
+                    PFD0_CLKGATE: pfd0_clkgate,
+                    PFD1_CLKGATE: pfd1_clkgate,
+                    PFD2_CLKGATE: pfd2_clkgate,
+                    PFD3_CLKGATE: pfd3_clkgate
                 );
 
                 // Safety: PDFx_FRAC is 6 bits wide. By the implementations
                 // of the `Frequency(..)` newtypes, the wrapped values will
                 // never exceed a 6 bit value.
-                write_reg!(ral::ccm_analog, handle.analog, $value,
-                           PFD0_FRAC: pfd0_frac,
-                           PFD1_FRAC: pfd1_frac,
-                           PFD2_FRAC: pfd2_frac,
-                           PFD3_FRAC: pfd3_frac
+                write_reg!(
+                    ral::ccm_analog,
+                    handle.analog,
+                    $value,
+                    PFD0_FRAC: pfd0_frac,
+                    PFD1_FRAC: pfd1_frac,
+                    PFD2_FRAC: pfd2_frac,
+                    PFD3_FRAC: pfd3_frac
                 );
             }
         }

--- a/imxrt-hal/src/ccm/arm_clock.rs
+++ b/imxrt-hal/src/ccm/arm_clock.rs
@@ -6,7 +6,7 @@
 //! [`set_arm_clock` routine]: https://github.com/PaulStoffregen/cores/blob/master/teensy4/clockspeed.c
 
 use imxrt_ral as ral;
-use ral::{read_reg, modify_reg, write_reg};
+use ral::{modify_reg, read_reg, write_reg};
 
 /// Note that while the value is limited to u8 the return
 /// is u32 to easily compare against register read values which are always u32
@@ -95,7 +95,10 @@ pub fn set_arm_clock(
     while read_reg!(ral::ccm_analog, ccm_analog, PLL_ARM, LOCK) == 0 {
         core::sync::atomic::spin_loop_hint();
     }
-    log::debug!("ARM PLL = 0x{:x}", read_reg!(ral::ccm_analog, ccm_analog, PLL_ARM));
+    log::debug!(
+        "ARM PLL = 0x{:x}",
+        read_reg!(ral::ccm_analog, ccm_analog, PLL_ARM)
+    );
 
     write_reg!(ral::ccm, ccm, CACRR, ARM_PODF: (div_arm - 1));
     while read_reg!(ral::ccm, ccm, CDHIPR, ARM_PODF_BUSY) > 0 {
@@ -137,7 +140,15 @@ fn select_alt_clock(ccm: &ral::ccm::Instance, ccm_analog: &ral::ccm_analog::Inst
         log::debug!("Choosing alternative clock before reconfiguring ARM PLL...");
         use ral::ccm::{CBCDR::PERIPH_CLK2_PODF, CBCMR::PERIPH_CLK2_SEL};
 
-        let (usb_pll_enable, usb_pll_en_usb_clks, usb_pll_power, usb_pll_lock) = read_reg!(ral::ccm_analog, ccm_analog, PLL_USB1, ENABLE, EN_USB_CLKS, POWER, LOCK);
+        let (usb_pll_enable, usb_pll_en_usb_clks, usb_pll_power, usb_pll_lock) = read_reg!(
+            ral::ccm_analog,
+            ccm_analog,
+            PLL_USB1,
+            ENABLE,
+            EN_USB_CLKS,
+            POWER,
+            LOCK
+        );
         let (sel, div) = if usb_pll_enable > 0
             && usb_pll_en_usb_clks > 0
             && usb_pll_power > 0

--- a/imxrt-hal/src/gpio.rs
+++ b/imxrt-hal/src/gpio.rs
@@ -10,18 +10,18 @@ pub struct GPIO7;
 
 #[doc(hidden)]
 pub trait IntoRegister {
-    fn into_reg() -> *const crate::ral::gpio1::RegisterBlock;
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock;
 }
 
 impl IntoRegister for GPIO2 {
-    fn into_reg() -> *const crate::ral::gpio1::RegisterBlock {
-        crate::ral::GPIO2::ptr()
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+        crate::ral::GPIO2
     }
 }
 
 impl IntoRegister for GPIO7 {
-    fn into_reg() -> *const crate::ral::gpio1::RegisterBlock {
-        crate::ral::GPIO7::ptr()
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+        crate::ral::GPIO7
     }
 }
 
@@ -36,7 +36,7 @@ macro_rules! _ios_impl {
 
             impl<GPIO: IntoRegister> $io<GPIO, Input> {
                 pub fn output(self) -> $io<GPIO, Output> {
-                    unsafe { (*GPIO::into_reg()).gdir.modify(|r, w| w.bits(self.offset | r.bits()))};
+                    unsafe { (*GPIO::into_reg()).GDIR.modify(|r, w| w.bits(self.offset | r.bits()))};
                     $io{ _gpio: core::marker::PhantomData, _dir: core::marker::PhantomData, offset: self.offset }
                 }
             }
@@ -124,5 +124,5 @@ macro_rules! ios {
 }
 
 ios! {
-    3, IO03: [GPIO2, gpio2, crate::iomuxc::gpio::GPIO_B0_03<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    3, IO03: [GPIO2, gpio2, crate::iomuxc::gpio::GPIO_B0_03<crate::iomuxc::Alt5>, FAST: (GPIO7, GPR27)],
 }

--- a/imxrt-hal/src/iomuxc.rs
+++ b/imxrt-hal/src/iomuxc.rs
@@ -37,6 +37,9 @@ pub struct Alt8;
 pub struct Alt9;
 
 pub struct IOMUXC {
+    // private keep this instance so it is taken
+    iomuxc: crate::ral::iomuxc::Instance,
+
     //
     // GPIO_B0
     //
@@ -81,59 +84,61 @@ pub struct IOMUXC {
     pub gpio_emc_08: gpio::GPIO_EMC_08<Alt5>,
     pub gpio_emc_31: gpio::GPIO_EMC_31<Alt5>,
     pub gpio_emc_32: gpio::GPIO_EMC_32<Alt5>,
-    //
+
     // GPRs
-    //
     pub gpr: GPR,
 }
 
 impl IOMUXC {
-    pub(crate) fn new(iomuxc: crate::ral::iomuxc::IOMUXC) -> Self {
+    pub(crate) fn new(iomuxc: crate::ral::iomuxc::Instance) -> Self {
         Self {
+            // Take the instance so no other code may
+            iomuxc: iomuxc,
+
             //
             // GPIO_B0
             //
-            gpio_b0_03: gpio::GPIO_B0_03::new(&iomuxc),
-            gpio_b0_10: gpio::GPIO_B0_10::new(&iomuxc),
-            gpio_b0_11: gpio::GPIO_B0_11::new(&iomuxc),
+            gpio_b0_03: gpio::GPIO_B0_03::new(),
+            gpio_b0_10: gpio::GPIO_B0_10::new(),
+            gpio_b0_11: gpio::GPIO_B0_11::new(),
             //
             // GPIO_B1
             //
-            gpio_b1_00: gpio::GPIO_B1_00::new(&iomuxc),
-            gpio_b1_01: gpio::GPIO_B1_01::new(&iomuxc),
+            gpio_b1_00: gpio::GPIO_B1_00::new(),
+            gpio_b1_01: gpio::GPIO_B1_01::new(),
             //
             // GPIO_AD_B0
             //
-            gpio_ad_b0_02: gpio::GPIO_AD_B0_02::new(&iomuxc),
-            gpio_ad_b0_03: gpio::GPIO_AD_B0_03::new(&iomuxc),
-            gpio_ad_b0_12: gpio::GPIO_AD_B0_12::new(&iomuxc),
-            gpio_ad_b0_13: gpio::GPIO_AD_B0_13::new(&iomuxc),
+            gpio_ad_b0_02: gpio::GPIO_AD_B0_02::new(),
+            gpio_ad_b0_03: gpio::GPIO_AD_B0_03::new(),
+            gpio_ad_b0_12: gpio::GPIO_AD_B0_12::new(),
+            gpio_ad_b0_13: gpio::GPIO_AD_B0_13::new(),
             //
             // GPIO_AD_B1
             //
-            gpio_ad_b1_00: gpio::GPIO_AD_B1_00::new(&iomuxc),
-            gpio_ad_b1_01: gpio::GPIO_AD_B1_01::new(&iomuxc),
-            gpio_ad_b1_02: gpio::GPIO_AD_B1_02::new(&iomuxc),
-            gpio_ad_b1_03: gpio::GPIO_AD_B1_03::new(&iomuxc),
-            gpio_ad_b1_06: gpio::GPIO_AD_B1_06::new(&iomuxc),
-            gpio_ad_b1_07: gpio::GPIO_AD_B1_07::new(&iomuxc),
-            gpio_ad_b1_10: gpio::GPIO_AD_B1_10::new(&iomuxc),
-            gpio_ad_b1_11: gpio::GPIO_AD_B1_11::new(&iomuxc),
+            gpio_ad_b1_00: gpio::GPIO_AD_B1_00::new(),
+            gpio_ad_b1_01: gpio::GPIO_AD_B1_01::new(),
+            gpio_ad_b1_02: gpio::GPIO_AD_B1_02::new(),
+            gpio_ad_b1_03: gpio::GPIO_AD_B1_03::new(),
+            gpio_ad_b1_06: gpio::GPIO_AD_B1_06::new(),
+            gpio_ad_b1_07: gpio::GPIO_AD_B1_07::new(),
+            gpio_ad_b1_10: gpio::GPIO_AD_B1_10::new(),
+            gpio_ad_b1_11: gpio::GPIO_AD_B1_11::new(),
             //
             // GPIO_SD_B0
             //
-            gpio_sd_b0_00: gpio::GPIO_SD_B0_00::new(&iomuxc),
-            gpio_sd_b0_01: gpio::GPIO_SD_B0_01::new(&iomuxc),
+            gpio_sd_b0_00: gpio::GPIO_SD_B0_00::new(),
+            gpio_sd_b0_01: gpio::GPIO_SD_B0_01::new(),
             //
             // GPIO_EMC
             //
-            gpio_emc_04: gpio::GPIO_EMC_04::new(&iomuxc),
-            gpio_emc_05: gpio::GPIO_EMC_05::new(&iomuxc),
-            gpio_emc_06: gpio::GPIO_EMC_06::new(&iomuxc),
-            gpio_emc_07: gpio::GPIO_EMC_07::new(&iomuxc),
-            gpio_emc_08: gpio::GPIO_EMC_08::new(&iomuxc),
-            gpio_emc_31: gpio::GPIO_EMC_31::new(&iomuxc),
-            gpio_emc_32: gpio::GPIO_EMC_32::new(&iomuxc),
+            gpio_emc_04: gpio::GPIO_EMC_04::new(),
+            gpio_emc_05: gpio::GPIO_EMC_05::new(),
+            gpio_emc_06: gpio::GPIO_EMC_06::new(),
+            gpio_emc_07: gpio::GPIO_EMC_07::new(),
+            gpio_emc_08: gpio::GPIO_EMC_08::new(),
+            gpio_emc_31: gpio::GPIO_EMC_31::new(),
+            gpio_emc_32: gpio::GPIO_EMC_32::new(),
 
             // GPRs
             gpr: GPR(()),
@@ -144,7 +149,7 @@ impl IOMUXC {
 pub struct GPR(());
 
 impl GPR {
-    pub(crate) fn gpr27(&mut self) -> &crate::ral::iomuxc_gpr::GPR27 {
-        unsafe { &(*crate::ral::IOMUXC_GPR::ptr()).gpr27 }
+    pub(crate) fn gpr27(&mut self) -> &crate::ral::RWRegister<u32> {
+        unsafe { &(*crate::ral::iomuxc_gpr::IOMUXC_GPR).GPR27 }
     }
 }

--- a/imxrt-hal/src/iomuxc/gpio/ad_b0.rs
+++ b/imxrt-hal/src/iomuxc/gpio/ad_b0.rs
@@ -1,117 +1,101 @@
 pad!(
     GPIO_AD_B0_00,
-    sw_mux_ctl_pad_gpio_ad_b0_00,
-    sw_pad_ctl_pad_gpio_ad_b0_00,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_00,
     SW_PAD_CTL_PAD_GPIO_AD_B0_00,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7]
 );
 pad!(
     GPIO_AD_B0_01,
-    sw_mux_ctl_pad_gpio_ad_b0_01,
-    sw_pad_ctl_pad_gpio_ad_b0_01,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_01,
     SW_PAD_CTL_PAD_GPIO_AD_B0_01,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7]
 );
 pad!(
     GPIO_AD_B0_02,
-    sw_mux_ctl_pad_gpio_ad_b0_02,
-    sw_pad_ctl_pad_gpio_ad_b0_02,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_02,
     SW_PAD_CTL_PAD_GPIO_AD_B0_02,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7]
 );
 pad!(
     GPIO_AD_B0_03,
-    sw_mux_ctl_pad_gpio_ad_b0_03,
-    sw_pad_ctl_pad_gpio_ad_b0_03,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_03,
     SW_PAD_CTL_PAD_GPIO_AD_B0_03,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7]
 );
 pad!(
     GPIO_AD_B0_04,
-    sw_mux_ctl_pad_gpio_ad_b0_04,
-    sw_pad_ctl_pad_gpio_ad_b0_04,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_04,
     SW_PAD_CTL_PAD_GPIO_AD_B0_04,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7]
 );
 pad!(
     GPIO_AD_B0_05,
-    sw_mux_ctl_pad_gpio_ad_b0_05,
-    sw_pad_ctl_pad_gpio_ad_b0_05,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_05,
     SW_PAD_CTL_PAD_GPIO_AD_B0_05,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7]
 );
 pad!(
     GPIO_AD_B0_06,
-    sw_mux_ctl_pad_gpio_ad_b0_06,
-    sw_pad_ctl_pad_gpio_ad_b0_06,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_06,
     SW_PAD_CTL_PAD_GPIO_AD_B0_06,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7]
 );
 pad!(
     GPIO_AD_B0_07,
-    sw_mux_ctl_pad_gpio_ad_b0_07,
-    sw_pad_ctl_pad_gpio_ad_b0_07,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_07,
     SW_PAD_CTL_PAD_GPIO_AD_B0_07,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7]
 );
 pad!(
     GPIO_AD_B0_08,
-    sw_mux_ctl_pad_gpio_ad_b0_08,
-    sw_pad_ctl_pad_gpio_ad_b0_08,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_08,
     SW_PAD_CTL_PAD_GPIO_AD_B0_08,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7]
 );
 // Skip 8
 pad!(
     GPIO_AD_B0_09,
-    sw_mux_ctl_pad_gpio_ad_b0_09,
-    sw_pad_ctl_pad_gpio_ad_b0_09,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_09,
     SW_PAD_CTL_PAD_GPIO_AD_B0_09,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt9]
 );
 // Add 8
 pad!(
     GPIO_AD_B0_10,
-    sw_mux_ctl_pad_gpio_ad_b0_10,
-    sw_pad_ctl_pad_gpio_ad_b0_10,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_10,
     SW_PAD_CTL_PAD_GPIO_AD_B0_10,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8, alt9]
 );
 pad!(
     GPIO_AD_B0_11,
-    sw_mux_ctl_pad_gpio_ad_b0_11,
-    sw_pad_ctl_pad_gpio_ad_b0_11,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_11,
     SW_PAD_CTL_PAD_GPIO_AD_B0_11,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8, alt9]
 );
 // Back to just 8 alts
 pad!(
     GPIO_AD_B0_12,
-    sw_mux_ctl_pad_gpio_ad_b0_12,
-    sw_pad_ctl_pad_gpio_ad_b0_12,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_12,
     SW_PAD_CTL_PAD_GPIO_AD_B0_12,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7]
 );
 pad!(
     GPIO_AD_B0_13,
-    sw_mux_ctl_pad_gpio_ad_b0_13,
-    sw_pad_ctl_pad_gpio_ad_b0_13,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_13,
     SW_PAD_CTL_PAD_GPIO_AD_B0_13,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7]
 );
 // Skip 7...
 pad!(
     GPIO_AD_B0_14,
-    sw_mux_ctl_pad_gpio_ad_b0_14,
-    sw_pad_ctl_pad_gpio_ad_b0_14,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_14,
     SW_PAD_CTL_PAD_GPIO_AD_B0_14,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 // ...and it's back
 pad!(
     GPIO_AD_B0_15,
-    sw_mux_ctl_pad_gpio_ad_b0_15,
-    sw_pad_ctl_pad_gpio_ad_b0_15,
+    SW_MUX_CTL_PAD_GPIO_AD_B0_15,
     SW_PAD_CTL_PAD_GPIO_AD_B0_15,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8]
 );

--- a/imxrt-hal/src/iomuxc/gpio/ad_b1.rs
+++ b/imxrt-hal/src/iomuxc/gpio/ad_b1.rs
@@ -1,63 +1,55 @@
 pad!(
     GPIO_AD_B1_00,
-    sw_mux_ctl_pad_gpio_ad_b1_00,
-    sw_pad_ctl_pad_gpio_ad_b1_00,
+    SW_MUX_CTL_PAD_GPIO_AD_B1_00,
     SW_PAD_CTL_PAD_GPIO_AD_B1_00,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8, alt9]
 );
 
 pad!(
     GPIO_AD_B1_01,
-    sw_mux_ctl_pad_gpio_ad_b1_01,
-    sw_pad_ctl_pad_gpio_ad_b1_01,
+    SW_MUX_CTL_PAD_GPIO_AD_B1_01,
     SW_PAD_CTL_PAD_GPIO_AD_B1_01,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8, alt9]
 );
 
 pad!(
     GPIO_AD_B1_02,
-    sw_mux_ctl_pad_gpio_ad_b1_02,
-    sw_pad_ctl_pad_gpio_ad_b1_02,
+    SW_MUX_CTL_PAD_GPIO_AD_B1_02,
     SW_PAD_CTL_PAD_GPIO_AD_B1_02,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8, alt9]
 );
 
 pad!(
     GPIO_AD_B1_03,
-    sw_mux_ctl_pad_gpio_ad_b1_03,
-    sw_pad_ctl_pad_gpio_ad_b1_03,
+    SW_MUX_CTL_PAD_GPIO_AD_B1_03,
     SW_PAD_CTL_PAD_GPIO_AD_B1_03,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8, alt9]
 );
 
 pad!(
     GPIO_AD_B1_06,
-    sw_mux_ctl_pad_gpio_ad_b1_06,
-    sw_pad_ctl_pad_gpio_ad_b1_06,
+    SW_MUX_CTL_PAD_GPIO_AD_B1_06,
     SW_PAD_CTL_PAD_GPIO_AD_B1_06,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8, alt9]
 );
 
 pad!(
     GPIO_AD_B1_07,
-    sw_mux_ctl_pad_gpio_ad_b1_07,
-    sw_pad_ctl_pad_gpio_ad_b1_07,
+    SW_MUX_CTL_PAD_GPIO_AD_B1_07,
     SW_PAD_CTL_PAD_GPIO_AD_B1_07,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8, alt9]
 );
 
 pad!(
     GPIO_AD_B1_10,
-    sw_mux_ctl_pad_gpio_ad_b1_10,
-    sw_pad_ctl_pad_gpio_ad_b1_10,
+    SW_MUX_CTL_PAD_GPIO_AD_B1_10,
     SW_PAD_CTL_PAD_GPIO_AD_B1_10,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8, alt9]
 );
 
 pad!(
     GPIO_AD_B1_11,
-    sw_mux_ctl_pad_gpio_ad_b1_11,
-    sw_pad_ctl_pad_gpio_ad_b1_11,
+    SW_MUX_CTL_PAD_GPIO_AD_B1_11,
     SW_PAD_CTL_PAD_GPIO_AD_B1_11,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8, alt9]
 );

--- a/imxrt-hal/src/iomuxc/gpio/b0.rs
+++ b/imxrt-hal/src/iomuxc/gpio/b0.rs
@@ -1,106 +1,93 @@
 pad!(
     GPIO_B0_00,
-    sw_mux_ctl_pad_gpio_b0_00,
-    sw_pad_ctl_pad_gpio_b0_00,
+    SW_MUX_CTL_PAD_GPIO_B0_00,
     SW_PAD_CTL_PAD_GPIO_B0_00,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_01,
-    sw_mux_ctl_pad_gpio_b0_01,
-    sw_pad_ctl_pad_gpio_b0_01,
+    SW_MUX_CTL_PAD_GPIO_B0_01,
     SW_PAD_CTL_PAD_GPIO_B0_01,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
+
+#[cfg(feature = "imxrt106x")]
 pad!(
     GPIO_B0_03,
-    sw_mux_ctl_pad_gpio_b0_03,
-    sw_pad_ctl_pad_gpio_b0_03,
+    SW_MUX_CTL_PAD_GPIO_B0_03,
     SW_PAD_CTL_PAD_GPIO_B0_03,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_04,
-    sw_mux_ctl_pad_gpio_b0_04,
-    sw_pad_ctl_pad_gpio_b0_04,
+    SW_MUX_CTL_PAD_GPIO_B0_04,
     SW_PAD_CTL_PAD_GPIO_B0_04,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_05,
-    sw_mux_ctl_pad_gpio_b0_05,
-    sw_pad_ctl_pad_gpio_b0_05,
+    SW_MUX_CTL_PAD_GPIO_B0_05,
     SW_PAD_CTL_PAD_GPIO_B0_05,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_06,
-    sw_mux_ctl_pad_gpio_b0_06,
-    sw_pad_ctl_pad_gpio_b0_06,
+    SW_MUX_CTL_PAD_GPIO_B0_06,
     SW_PAD_CTL_PAD_GPIO_B0_06,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_07,
-    sw_mux_ctl_pad_gpio_b0_07,
-    sw_pad_ctl_pad_gpio_b0_07,
+    SW_MUX_CTL_PAD_GPIO_B0_07,
     SW_PAD_CTL_PAD_GPIO_B0_07,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_08,
-    sw_mux_ctl_pad_gpio_b0_08,
-    sw_pad_ctl_pad_gpio_b0_08,
+    SW_MUX_CTL_PAD_GPIO_B0_08,
     SW_PAD_CTL_PAD_GPIO_B0_08,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_09,
-    sw_mux_ctl_pad_gpio_b0_09,
-    sw_pad_ctl_pad_gpio_b0_09,
+    SW_MUX_CTL_PAD_GPIO_B0_09,
     SW_PAD_CTL_PAD_GPIO_B0_09,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_10,
-    sw_mux_ctl_pad_gpio_b0_10,
-    sw_pad_ctl_pad_gpio_b0_10,
+    SW_MUX_CTL_PAD_GPIO_B0_10,
     SW_PAD_CTL_PAD_GPIO_B0_10,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_11,
-    sw_mux_ctl_pad_gpio_b0_11,
-    sw_pad_ctl_pad_gpio_b0_11,
+    SW_MUX_CTL_PAD_GPIO_B0_11,
     SW_PAD_CTL_PAD_GPIO_B0_11,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_12,
-    sw_mux_ctl_pad_gpio_b0_12,
-    sw_pad_ctl_pad_gpio_b0_12,
+    SW_MUX_CTL_PAD_GPIO_B0_12,
     SW_PAD_CTL_PAD_GPIO_B0_12,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_13,
-    sw_mux_ctl_pad_gpio_b0_13,
-    sw_pad_ctl_pad_gpio_b0_13,
+    SW_MUX_CTL_PAD_GPIO_B0_13,
     SW_PAD_CTL_PAD_GPIO_B0_13,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
     GPIO_B0_14,
-    sw_mux_ctl_pad_gpio_b0_14,
-    sw_pad_ctl_pad_gpio_b0_14,
+    SW_MUX_CTL_PAD_GPIO_B0_14,
     SW_PAD_CTL_PAD_GPIO_B0_14,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 // Requires Alt9
 pad!(
     GPIO_B0_15,
-    sw_mux_ctl_pad_gpio_b0_15,
-    sw_pad_ctl_pad_gpio_b0_15,
+    SW_MUX_CTL_PAD_GPIO_B0_15,
     SW_PAD_CTL_PAD_GPIO_B0_15,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );

--- a/imxrt-hal/src/iomuxc/gpio/b1.rs
+++ b/imxrt-hal/src/iomuxc/gpio/b1.rs
@@ -2,32 +2,28 @@
 
 pad!(
     GPIO_B1_00,
-    sw_mux_ctl_pad_gpio_b1_00,
-    sw_pad_ctl_pad_gpio_b1_00,
+    SW_MUX_CTL_PAD_GPIO_B1_00,
     SW_PAD_CTL_PAD_GPIO_B1_00,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );
 
 pad!(
     GPIO_B1_01,
-    sw_mux_ctl_pad_gpio_b1_01,
-    sw_pad_ctl_pad_gpio_b1_01,
+    SW_MUX_CTL_PAD_GPIO_B1_01,
     SW_PAD_CTL_PAD_GPIO_B1_01,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );
 
 pad!(
     GPIO_B1_02,
-    sw_mux_ctl_pad_gpio_b1_02,
-    sw_pad_ctl_pad_gpio_b1_02,
+    SW_MUX_CTL_PAD_GPIO_B1_02,
     SW_PAD_CTL_PAD_GPIO_B1_02,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );
 
 pad!(
     GPIO_B1_03,
-    sw_mux_ctl_pad_gpio_b1_03,
-    sw_pad_ctl_pad_gpio_b1_03,
+    SW_MUX_CTL_PAD_GPIO_B1_03,
     SW_PAD_CTL_PAD_GPIO_B1_03,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );
@@ -36,32 +32,28 @@ pad!(
 
 pad!(
     GPIO_B1_04,
-    sw_mux_ctl_pad_gpio_b1_04,
-    sw_pad_ctl_pad_gpio_b1_04,
+    SW_MUX_CTL_PAD_GPIO_B1_04,
     SW_PAD_CTL_PAD_GPIO_B1_04,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt8, alt9]
 );
 
 pad!(
     GPIO_B1_05,
-    sw_mux_ctl_pad_gpio_b1_05,
-    sw_pad_ctl_pad_gpio_b1_05,
+    SW_MUX_CTL_PAD_GPIO_B1_05,
     SW_PAD_CTL_PAD_GPIO_B1_05,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt8, alt9]
 );
 
 pad!(
     GPIO_B1_06,
-    sw_mux_ctl_pad_gpio_b1_06,
-    sw_pad_ctl_pad_gpio_b1_06,
+    SW_MUX_CTL_PAD_GPIO_B1_06,
     SW_PAD_CTL_PAD_GPIO_B1_06,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt8, alt9]
 );
 
 pad!(
     GPIO_B1_07,
-    sw_mux_ctl_pad_gpio_b1_07,
-    sw_pad_ctl_pad_gpio_b1_07,
+    SW_MUX_CTL_PAD_GPIO_B1_07,
     SW_PAD_CTL_PAD_GPIO_B1_07,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt8, alt9]
 );
@@ -70,16 +62,14 @@ pad!(
 
 pad!(
     GPIO_B1_08,
-    sw_mux_ctl_pad_gpio_b1_08,
-    sw_pad_ctl_pad_gpio_b1_08,
+    SW_MUX_CTL_PAD_GPIO_B1_08,
     SW_PAD_CTL_PAD_GPIO_B1_08,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );
 
 pad!(
     GPIO_B1_09,
-    sw_mux_ctl_pad_gpio_b1_09,
-    sw_pad_ctl_pad_gpio_b1_09,
+    SW_MUX_CTL_PAD_GPIO_B1_09,
     SW_PAD_CTL_PAD_GPIO_B1_09,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );
@@ -88,16 +78,14 @@ pad!(
 
 pad!(
     GPIO_B1_10,
-    sw_mux_ctl_pad_gpio_b1_10,
-    sw_pad_ctl_pad_gpio_b1_10,
+    SW_MUX_CTL_PAD_GPIO_B1_10,
     SW_PAD_CTL_PAD_GPIO_B1_10,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt9]
 );
 
 pad!(
     GPIO_B1_11,
-    sw_mux_ctl_pad_gpio_b1_11,
-    sw_pad_ctl_pad_gpio_b1_11,
+    SW_MUX_CTL_PAD_GPIO_B1_11,
     SW_PAD_CTL_PAD_GPIO_B1_11,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt9]
 );
@@ -110,8 +98,7 @@ pad!(
 // missing alternatives. Thanks, svd2rust!
 pad!(
     GPIO_B1_12,
-    sw_mux_ctl_pad_gpio_b1_12,
-    sw_pad_ctl_pad_gpio_b1_12,
+    SW_MUX_CTL_PAD_GPIO_B1_12,
     SW_PAD_CTL_PAD_GPIO_B1_12,
     [alt1, alt2, alt3, alt4, alt5, alt6, alt9]
 );
@@ -120,24 +107,21 @@ pad!(
 
 pad!(
     GPIO_B1_13,
-    sw_mux_ctl_pad_gpio_b1_13,
-    sw_pad_ctl_pad_gpio_b1_13,
+    SW_MUX_CTL_PAD_GPIO_B1_13,
     SW_PAD_CTL_PAD_GPIO_B1_13,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );
 
 pad!(
     GPIO_B1_14,
-    sw_mux_ctl_pad_gpio_b1_14,
-    sw_pad_ctl_pad_gpio_b1_14,
+    SW_MUX_CTL_PAD_GPIO_B1_14,
     SW_PAD_CTL_PAD_GPIO_B1_14,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );
 
 pad!(
     GPIO_B1_15,
-    sw_mux_ctl_pad_gpio_b1_15,
-    sw_pad_ctl_pad_gpio_b1_15,
+    SW_MUX_CTL_PAD_GPIO_B1_15,
     SW_PAD_CTL_PAD_GPIO_B1_15,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );

--- a/imxrt-hal/src/iomuxc/gpio/emc.rs
+++ b/imxrt-hal/src/iomuxc/gpio/emc.rs
@@ -1,55 +1,48 @@
 pad!(
     GPIO_EMC_04,
-    sw_mux_ctl_pad_gpio_emc_04,
-    sw_pad_ctl_pad_gpio_emc_04,
+    SW_MUX_CTL_PAD_GPIO_EMC_04,
     SW_PAD_CTL_PAD_GPIO_EMC_04,
     [alt0, alt1, alt2, alt3, alt4, alt5]
 );
 
 pad!(
     GPIO_EMC_05,
-    sw_mux_ctl_pad_gpio_emc_05,
-    sw_pad_ctl_pad_gpio_emc_05,
+    SW_MUX_CTL_PAD_GPIO_EMC_05,
     SW_PAD_CTL_PAD_GPIO_EMC_05,
     [alt0, alt1, alt2, alt3, alt4, alt5]
 );
 
 pad!(
     GPIO_EMC_06,
-    sw_mux_ctl_pad_gpio_emc_06,
-    sw_pad_ctl_pad_gpio_emc_06,
+    SW_MUX_CTL_PAD_GPIO_EMC_06,
     SW_PAD_CTL_PAD_GPIO_EMC_06,
     [alt0, alt1, alt2, alt3, alt4, alt5]
 );
 
 pad!(
     GPIO_EMC_07,
-    sw_mux_ctl_pad_gpio_emc_07,
-    sw_pad_ctl_pad_gpio_emc_07,
+    SW_MUX_CTL_PAD_GPIO_EMC_07,
     SW_PAD_CTL_PAD_GPIO_EMC_07,
     [alt0, alt1, alt2, alt3, alt4, alt5]
 );
 
 pad!(
     GPIO_EMC_08,
-    sw_mux_ctl_pad_gpio_emc_08,
-    sw_pad_ctl_pad_gpio_emc_08,
+    SW_MUX_CTL_PAD_GPIO_EMC_08,
     SW_PAD_CTL_PAD_GPIO_EMC_08,
     [alt0, alt1, alt2, alt3, alt4, alt5]
 );
 
 pad!(
     GPIO_EMC_31,
-    sw_mux_ctl_pad_gpio_emc_31,
-    sw_pad_ctl_pad_gpio_emc_31,
+    SW_MUX_CTL_PAD_GPIO_EMC_31,
     SW_PAD_CTL_PAD_GPIO_EMC_31,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt8]
 );
 
 pad!(
     GPIO_EMC_32,
-    sw_mux_ctl_pad_gpio_emc_32,
-    sw_pad_ctl_pad_gpio_emc_32,
+    SW_MUX_CTL_PAD_GPIO_EMC_32,
     SW_PAD_CTL_PAD_GPIO_EMC_32,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt8]
 );

--- a/imxrt-hal/src/iomuxc/gpio/sd_b0.rs
+++ b/imxrt-hal/src/iomuxc/gpio/sd_b0.rs
@@ -1,8 +1,7 @@
 // No ALT7...?
 pad!(
     GPIO_SD_B0_00,
-    sw_mux_ctl_pad_gpio_sd_b0_00,
-    sw_pad_ctl_pad_gpio_sd_b0_00,
+    SW_MUX_CTL_PAD_GPIO_SD_B0_00,
     SW_PAD_CTL_PAD_GPIO_SD_B0_00,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );
@@ -10,8 +9,7 @@ pad!(
 // No ALT7...?
 pad!(
     GPIO_SD_B0_01,
-    sw_mux_ctl_pad_gpio_sd_b0_01,
-    sw_pad_ctl_pad_gpio_sd_b0_01,
+    SW_MUX_CTL_PAD_GPIO_SD_B0_01,
     SW_PAD_CTL_PAD_GPIO_SD_B0_01,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );

--- a/imxrt-hal/src/iomuxc/macros.rs
+++ b/imxrt-hal/src/iomuxc/macros.rs
@@ -2,13 +2,9 @@ macro_rules! alt0 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt0 setting
         pub fn alt0(self) -> $Pad<$crate::iomuxc::Alt0> {
-            self.iomuxc().$mux_mod.modify(|_, w| {
-                w.mux_mode()
-                    .variant($crate::ral::iomuxc::$mux_mod::MUX_MODE_A::ALT0)
-            });
+            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT0) };
             $Pad {
                 _alt: core::marker::PhantomData,
-                iomuxc: self.iomuxc,
             }
         }
     };
@@ -18,13 +14,9 @@ macro_rules! alt1 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt1 setting
         pub fn alt1(self) -> $Pad<$crate::iomuxc::Alt1> {
-            self.iomuxc().$mux_mod.modify(|_, w| {
-                w.mux_mode()
-                    .variant($crate::ral::iomuxc::$mux_mod::MUX_MODE_A::ALT1)
-            });
+            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT1) };
             $Pad {
                 _alt: core::marker::PhantomData,
-                iomuxc: self.iomuxc,
             }
         }
     };
@@ -34,13 +26,9 @@ macro_rules! alt2 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt2 setting
         pub fn alt2(self) -> $Pad<$crate::iomuxc::Alt2> {
-            self.iomuxc().$mux_mod.modify(|_, w| {
-                w.mux_mode()
-                    .variant($crate::ral::iomuxc::$mux_mod::MUX_MODE_A::ALT2)
-            });
+            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT2) };
             $Pad {
                 _alt: core::marker::PhantomData,
-                iomuxc: self.iomuxc,
             }
         }
     };
@@ -50,13 +38,9 @@ macro_rules! alt3 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt3 setting
         pub fn alt3(self) -> $Pad<$crate::iomuxc::Alt3> {
-            self.iomuxc().$mux_mod.modify(|_, w| {
-                w.mux_mode()
-                    .variant($crate::ral::iomuxc::$mux_mod::MUX_MODE_A::ALT3)
-            });
+            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT3) };
             $Pad {
                 _alt: core::marker::PhantomData,
-                iomuxc: self.iomuxc,
             }
         }
     };
@@ -66,13 +50,9 @@ macro_rules! alt4 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt4 setting
         pub fn alt4(self) -> $Pad<$crate::iomuxc::Alt4> {
-            self.iomuxc().$mux_mod.modify(|_, w| {
-                w.mux_mode()
-                    .variant($crate::ral::iomuxc::$mux_mod::MUX_MODE_A::ALT4)
-            });
+            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT4) };
             $Pad {
                 _alt: core::marker::PhantomData,
-                iomuxc: self.iomuxc,
             }
         }
     };
@@ -82,13 +62,9 @@ macro_rules! alt5 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt5 setting
         pub fn alt5(self) -> $Pad<$crate::iomuxc::Alt5> {
-            self.iomuxc().$mux_mod.modify(|_, w| {
-                w.mux_mode()
-                    .variant($crate::ral::iomuxc::$mux_mod::MUX_MODE_A::ALT5)
-            });
+            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT5) };
             $Pad {
                 _alt: core::marker::PhantomData,
-                iomuxc: self.iomuxc,
             }
         }
     };
@@ -98,13 +74,9 @@ macro_rules! alt6 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt6 setting
         pub fn alt6(self) -> $Pad<$crate::iomuxc::Alt6> {
-            self.iomuxc().$mux_mod.modify(|_, w| {
-                w.mux_mode()
-                    .variant($crate::ral::iomuxc::$mux_mod::MUX_MODE_A::ALT6)
-            });
+            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT6) };
             $Pad {
                 _alt: core::marker::PhantomData,
-                iomuxc: self.iomuxc,
             }
         }
     };
@@ -114,13 +86,9 @@ macro_rules! alt7 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt7 setting
         pub fn alt7(self) -> $Pad<$crate::iomuxc::Alt7> {
-            self.iomuxc().$mux_mod.modify(|_, w| {
-                w.mux_mode()
-                    .variant($crate::ral::iomuxc::$mux_mod::MUX_MODE_A::ALT7)
-            });
+            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT7) };
             $Pad {
                 _alt: core::marker::PhantomData,
-                iomuxc: self.iomuxc,
             }
         }
     };
@@ -130,13 +98,9 @@ macro_rules! alt8 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt8 setting
         pub fn alt8(self) -> $Pad<$crate::iomuxc::Alt8> {
-            self.iomuxc().$mux_mod.modify(|_, w| {
-                w.mux_mode()
-                    .variant($crate::ral::iomuxc::$mux_mod::MUX_MODE_A::ALT8)
-            });
+            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT8) };
             $Pad {
                 _alt: core::marker::PhantomData,
-                iomuxc: self.iomuxc,
             }
         }
     };
@@ -146,44 +110,39 @@ macro_rules! alt9 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt9 setting
         pub fn alt9(self) -> $Pad<$crate::iomuxc::Alt9> {
-            self.iomuxc().$mux_mod.modify(|_, w| {
-                w.mux_mode()
-                    .variant($crate::ral::iomuxc::$mux_mod::MUX_MODE_A::ALT9)
-            });
+            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT9) };
             $Pad {
                 _alt: core::marker::PhantomData,
-                iomuxc: self.iomuxc,
             }
         }
     };
 }
 
 macro_rules! pad {
-    ($Pad:ident, $mux_mod:ident, $pad_mod:ident, $pad_ty:ident, [$($alt_macro:ident),+]) => {
+    ($Pad:ident, $mux_mod:ident, $pad_mod:ident, [$($alt_macro:ident),+]) => {
         pub struct $Pad<Alt> {
             _alt: core::marker::PhantomData<Alt>,
-            iomuxc: *const $crate::ral::iomuxc::RegisterBlock,
         }
         impl<Alt> $Pad<Alt> {
             $(
                 $alt_macro!($Pad, $mux_mod);
             )+
 
-            #[allow(dead_code)] // TODO Remove once all pads are exposed in IOMUXC, and these are properly used
-            pub(crate) fn new(iomuxc: &$crate::ral::iomuxc::RegisterBlock) -> Self {
+            // TODO Remove once all pads are exposed in IOMUXC, and these are properly used
+            #[allow(dead_code)]
+            pub(crate) fn new() -> Self {
                 Self {
                     _alt: core::marker::PhantomData,
-                    iomuxc,
                 }
             }
 
             pub(crate) fn iomuxc(&self) -> &$crate::ral::iomuxc::RegisterBlock {
                 // Safety: register block is always valid
-                unsafe { &*self.iomuxc }
+                unsafe { &*$crate::ral::iomuxc::IOMUXC }
             }
 
             #[allow(dead_code)] // Method may not be used on a pin
-            pub(crate) fn pad(&self) -> &$crate::ral::iomuxc::$pad_ty {
+            pub(crate) fn pad(&self) -> &$crate::ral::RWRegister<u32> {
                 &self.iomuxc().$pad_mod
             }
 
@@ -191,14 +150,14 @@ macro_rules! pad {
             /// the input path for the pin.
             #[allow(dead_code)] // Method may not be used on a pin
             pub(crate) fn sion_enable(&self) {
-                self.iomuxc().$mux_mod.modify(|_, w| w.sion().set_bit());
+                unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, SION: $crate::ral::iomuxc::$mux_mod::SION::RW::ENABLED) };
             }
 
             /// Disables software input on (SION) for the pin. This means that
             /// the pin's input path is determined by its functionality.
             #[allow(dead_code)] // Method may not be used on a pin
             pub(crate) fn sion_disable(&self) {
-                self.iomuxc().$mux_mod.modify(|_, w| w.sion().clear_bit());
+                unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, SION: $crate::ral::iomuxc::$mux_mod::SION::RW::DISABLED) };
             }
         }
     };

--- a/imxrt-hal/src/lib.rs
+++ b/imxrt-hal/src/lib.rs
@@ -21,7 +21,7 @@ pub use imxrt_ral as ral;
 pub mod ccm;
 //pub mod gpio;
 //pub mod i2c;
-//pub mod iomuxc;
+pub mod iomuxc;
 //pub mod pit;
 //pub mod pwm;
 //pub mod uart;
@@ -37,7 +37,7 @@ pub mod dcdc {
 }
 
 pub struct Peripherals {
-    //pub iomuxc: iomuxc::IOMUXC,
+    pub iomuxc: iomuxc::IOMUXC,
     //pub systick: ral::SYST,
     pub ccm: ccm::CCM,
     //pub pit: pit::UnclockedPIT,
@@ -53,7 +53,7 @@ pub struct Peripherals {
 impl Peripherals {
     pub fn take() -> Option<Self> {
         let p = Peripherals {
-            //iomuxc: iomuxc::IOMUXC::new(p.IOMUXC),
+            iomuxc: iomuxc::IOMUXC::new(ral::iomuxc::IOMUXC::take()?),
             //systick: cp.SYST,
             ccm: ccm::CCM::new(ral::ccm::CCM::take()?, ral::ccm_analog::CCM_ANALOG::take()?),
             //pit: pit::UnclockedPIT::new(p.PIT),


### PR DESCRIPTION
Note that each pad requires unsafe modify_reg() calls to convert to a
particular pads alternate usage.

This should be safe because each pad has its own register pair (mux/pad) for
setting things up. So long as the only place where these registers are
used is in the iomuxc instance in struct Peripherals, this is like just
fine.

I'm not excited to have to import the modify_reg!() macro in each gpio module, I didn't try using it using crate::ral::modify_reg!() which perhaps works already, will try later perhaps.