### PR TITLE
Imxrt ral repr c

### DIFF
--- a/imxrt-ral/imxrtral.py
+++ b/imxrt-ral/imxrtral.py
@@ -768,6 +768,7 @@ class PeripheralPrototype(Node):
             address += register.size // 8
         lines = "\n".join(lines)
         return f"""
+        #[repr(C)]
         pub struct RegisterBlock {{
             {lines}
         }}"""


### PR DESCRIPTION
Adds #[repr(C)] to RegisterBlock structs to ensure memory alignment

Based on #16 
Fixes #13 