### PR TITLE
Port remaining GPIOs from teensy4-rs

### DIFF
--- a/imxrt-hal/src/gpio.rs
+++ b/imxrt-hal/src/gpio.rs
@@ -1,21 +1,61 @@
-use embedded_hal::digital::v2::{OutputPin, StatefulOutputPin, ToggleableOutputPin};
+use embedded_hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
 
 /// Denotes that a pin is configured as an input
 pub struct Input;
 /// Denotes that a pin is configured as an output
 pub struct Output;
 
+pub struct GPIO1;
 pub struct GPIO2;
+pub struct GPIO3;
+pub struct GPIO4;
+pub struct GPIO5;
+pub struct GPIO6;
 pub struct GPIO7;
+
+pub trait IntoGpio {
+    type Gpio;
+    fn into_gpio(self) -> Self::Gpio;
+}
 
 #[doc(hidden)]
 pub trait IntoRegister {
     fn into_reg() -> *const crate::ral::gpio::RegisterBlock;
 }
 
+impl IntoRegister for GPIO1 {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+        crate::ral::gpio::GPIO1
+    }
+}
+
 impl IntoRegister for GPIO2 {
     fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
         crate::ral::gpio::GPIO2
+    }
+}
+
+impl IntoRegister for GPIO3 {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+        crate::ral::gpio::GPIO3
+    }
+}
+
+impl IntoRegister for GPIO4 {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+        crate::ral::gpio::GPIO4
+    }
+}
+
+impl IntoRegister for GPIO5 {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+        crate::ral::gpio::GPIO5
+    }
+}
+
+impl IntoRegister for GPIO6 {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+        crate::ral::gpio::GPIO6
     }
 }
 
@@ -44,6 +84,17 @@ macro_rules! _ios_impl {
                         regs.GDIR.write(gdir0);
                     };
                     $io{ _gpio: core::marker::PhantomData, _dir: core::marker::PhantomData, offset: self.offset }
+                }
+            }
+            impl<GPIO: IntoRegister> InputPin for $io<GPIO, Input> {
+                type Error = core::convert::Infallible; // '!' Not available on stable
+
+                fn is_low(&self) -> Result<bool, Self::Error> {
+                    Ok(unsafe { (*GPIO::into_reg()).PSR.read() & self.offset == 0 })
+                }
+
+                fn is_high(&self) -> Result<bool, Self::Error> {
+                    Ok(unsafe { (*GPIO::into_reg()).PSR.read() & self.offset != 0 })
                 }
             }
 
@@ -107,6 +158,19 @@ macro_rules! _ios_ctor {
                     }
                 }
             }
+
+            impl From<$pad> for $io<$bank, Input> {
+                fn from(pad: $pad) -> Self {
+                    Self::$ctor(pad)
+                }
+            }
+
+            impl IntoGpio for $pad {
+                type Gpio = $io<$bank, Input>;
+                fn into_gpio(self) -> Self::Gpio {
+                    $io::<$bank, Input>::$ctor(self)
+                }
+            }
         )+
     };
 }
@@ -146,6 +210,93 @@ macro_rules! ios {
     };
 }
 
+// Bank 1
 ios! {
-    3, IO03: [GPIO2, gpio2, crate::iomuxc::gpio::GPIO_B0_03<crate::iomuxc::Alt5>, FAST: (GPIO7, GPR27)],
+    0, GPIO1IO00: [GPIO1, gpio0, crate::iomuxc::gpio::GPIO_AD_B0_00<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    1, GPIO1IO01: [GPIO1, gpio1, crate::iomuxc::gpio::GPIO_AD_B0_01<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    2, GPIO1IO02: [GPIO1, gpio2, crate::iomuxc::gpio::GPIO_AD_B0_02<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    3, GPIO1IO03: [GPIO1, gpio3, crate::iomuxc::gpio::GPIO_AD_B0_03<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    4, GPIO1IO04: [GPIO1, gpio4, crate::iomuxc::gpio::GPIO_AD_B0_04<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    5, GPIO1IO05: [GPIO1, gpio5, crate::iomuxc::gpio::GPIO_AD_B0_05<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    6, GPIO1IO06: [GPIO1, gpio6, crate::iomuxc::gpio::GPIO_AD_B0_06<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    7, GPIO1IO07: [GPIO1, gpio7, crate::iomuxc::gpio::GPIO_AD_B0_07<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    8, GPIO1IO08: [GPIO1, gpio8, crate::iomuxc::gpio::GPIO_AD_B0_08<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    9, GPIO1IO09: [GPIO1, gpio9, crate::iomuxc::gpio::GPIO_AD_B0_09<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    10, GPIO1IO10: [GPIO1, gpio10, crate::iomuxc::gpio::GPIO_AD_B0_10<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    11, GPIO1IO11: [GPIO1, gpio11, crate::iomuxc::gpio::GPIO_AD_B0_11<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    12, GPIO1IO12: [GPIO1, gpio12, crate::iomuxc::gpio::GPIO_AD_B0_12<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    13, GPIO1IO13: [GPIO1, gpio13, crate::iomuxc::gpio::GPIO_AD_B0_13<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    14, GPIO1IO14: [GPIO1, gpio14, crate::iomuxc::gpio::GPIO_AD_B0_14<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    15, GPIO1IO15: [GPIO1, gpio15, crate::iomuxc::gpio::GPIO_AD_B0_15<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    16, GPIO1IO16: [GPIO1, gpio16, crate::iomuxc::gpio::GPIO_AD_B1_00<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    17, GPIO1IO17: [GPIO1, gpio17, crate::iomuxc::gpio::GPIO_AD_B1_01<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    18, GPIO1IO18: [GPIO1, gpio18, crate::iomuxc::gpio::GPIO_AD_B1_02<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    19, GPIO1IO19: [GPIO1, gpio19, crate::iomuxc::gpio::GPIO_AD_B1_03<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    // TODO: more from this bank? Missing 20..=31
+}
+
+// Bank 2
+ios! {
+    0, GPIO2IO00: [GPIO2, gpio0, crate::iomuxc::gpio::GPIO_B0_00<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    1, GPIO2IO01: [GPIO2, gpio1, crate::iomuxc::gpio::GPIO_B0_01<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    2, GPIO2IO02: [GPIO2, gpio2, crate::iomuxc::gpio::GPIO_B0_02<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    3, GPIO2IO03: [GPIO2, gpio3, crate::iomuxc::gpio::GPIO_B0_03<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    4, GPIO2IO04: [GPIO2, gpio4, crate::iomuxc::gpio::GPIO_B0_04<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    5, GPIO2IO05: [GPIO2, gpio5, crate::iomuxc::gpio::GPIO_B0_05<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    6, GPIO2IO06: [GPIO2, gpio6, crate::iomuxc::gpio::GPIO_B0_06<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    7, GPIO2IO07: [GPIO2, gpio7, crate::iomuxc::gpio::GPIO_B0_07<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    8, GPIO2IO08: [GPIO2, gpio8, crate::iomuxc::gpio::GPIO_B0_08<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    9, GPIO2IO09: [GPIO2, gpio9, crate::iomuxc::gpio::GPIO_B0_09<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    10, GPIO2IO10: [GPIO2, gpio10, crate::iomuxc::gpio::GPIO_B0_10<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    11, GPIO2IO11: [GPIO2, gpio11, crate::iomuxc::gpio::GPIO_B0_11<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    12, GPIO2IO12: [GPIO2, gpio12, crate::iomuxc::gpio::GPIO_B0_12<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    13, GPIO2IO13: [GPIO2, gpio13, crate::iomuxc::gpio::GPIO_B0_13<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    14, GPIO2IO14: [GPIO2, gpio14, crate::iomuxc::gpio::GPIO_B0_14<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    15, GPIO2IO15: [GPIO2, gpio15, crate::iomuxc::gpio::GPIO_B0_15<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    16, GPIO2IO16: [GPIO2, gpio16, crate::iomuxc::gpio::GPIO_B1_00<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    17, GPIO2IO17: [GPIO2, gpio17, crate::iomuxc::gpio::GPIO_B1_01<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    18, GPIO2IO18: [GPIO2, gpio18, crate::iomuxc::gpio::GPIO_B1_02<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    19, GPIO2IO19: [GPIO2, gpio19, crate::iomuxc::gpio::GPIO_B1_03<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    20, GPIO2IO20: [GPIO2, gpio20, crate::iomuxc::gpio::GPIO_B1_04<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    21, GPIO2IO21: [GPIO2, gpio21, crate::iomuxc::gpio::GPIO_B1_05<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    22, GPIO2IO22: [GPIO2, gpio22, crate::iomuxc::gpio::GPIO_B1_06<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    23, GPIO2IO23: [GPIO2, gpio23, crate::iomuxc::gpio::GPIO_B1_07<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    24, GPIO2IO24: [GPIO2, gpio24, crate::iomuxc::gpio::GPIO_B1_08<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    25, GPIO2IO25: [GPIO2, gpio25, crate::iomuxc::gpio::GPIO_B1_09<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    26, GPIO2IO26: [GPIO2, gpio26, crate::iomuxc::gpio::GPIO_B1_10<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    27, GPIO2IO27: [GPIO2, gpio27, crate::iomuxc::gpio::GPIO_B1_11<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    28, GPIO2IO28: [GPIO2, gpio28, crate::iomuxc::gpio::GPIO_B1_12<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    29, GPIO2IO29: [GPIO2, gpio29, crate::iomuxc::gpio::GPIO_B1_13<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    30, GPIO2IO30: [GPIO2, gpio30, crate::iomuxc::gpio::GPIO_B1_14<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+    31, GPIO2IO31: [GPIO2, gpio31, crate::iomuxc::gpio::GPIO_B1_15<crate::iomuxc::Alt5>, FAST: (GPIO7, gpr27)],
+}
+
+// Bank 3, missing quite a few here...
+ios! {
+    // gap 0..=5
+    6, GPIO3IO06: [GPIO3, gpio6, crate::iomuxc::gpio::GPIO_SD_B1_06<crate::iomuxc::Alt5>],
+    7, GPIO3IO07: [GPIO3, gpio7, crate::iomuxc::gpio::GPIO_SD_B1_07<crate::iomuxc::Alt5>],
+    8, GPIO3IO08: [GPIO3, gpio8, crate::iomuxc::gpio::GPIO_SD_B1_08<crate::iomuxc::Alt5>],
+    9, GPIO3IO09: [GPIO3, gpio9, crate::iomuxc::gpio::GPIO_SD_B1_09<crate::iomuxc::Alt5>],
+    // gap 10..=11
+    12, GPIO3IO12: [GPIO3, gpio12, crate::iomuxc::gpio::GPIO_SD_B0_00<crate::iomuxc::Alt5>],
+    13, GPIO3IO13: [GPIO3, gpio13, crate::iomuxc::gpio::GPIO_SD_B0_01<crate::iomuxc::Alt5>],
+    14, GPIO3IO14: [GPIO3, gpio14, crate::iomuxc::gpio::GPIO_SD_B0_02<crate::iomuxc::Alt5>],
+    15, GPIO3IO15: [GPIO3, gpio15, crate::iomuxc::gpio::GPIO_SD_B0_03<crate::iomuxc::Alt5>],
+    // gap 16..=17
+    18, GPIO3IO18: [GPIO3, gpio18, crate::iomuxc::gpio::GPIO_EMC_32<crate::iomuxc::Alt5>],
+    // gap 19..=27
+}
+
+// Bank 4, missing quite a few here...
+ios! {
+    // gap 0..=3
+    4, GPIO4IO04: [GPIO4, gpio4, crate::iomuxc::gpio::GPIO_EMC_04<crate::iomuxc::Alt5>],
+    5, GPIO4IO05: [GPIO4, gpio5, crate::iomuxc::gpio::GPIO_EMC_05<crate::iomuxc::Alt5>],
+    6, GPIO4IO06: [GPIO4, gpio6, crate::iomuxc::gpio::GPIO_EMC_06<crate::iomuxc::Alt5>],
+    // gap 7
+    8, GPIO4IO08: [GPIO4, gpio8, crate::iomuxc::gpio::GPIO_EMC_08<crate::iomuxc::Alt5>],
+    // gap 9..=29
+    30, GPIO4IO30: [GPIO4, gpio30, crate::iomuxc::gpio::GPIO_EMC_30<crate::iomuxc::Alt5>],
+    31, GPIO4IO31: [GPIO4, gpio31, crate::iomuxc::gpio::GPIO_EMC_31<crate::iomuxc::Alt5>],
 }

--- a/imxrt-hal/src/iomuxc.rs
+++ b/imxrt-hal/src/iomuxc.rs
@@ -42,6 +42,9 @@ pub struct IOMUXC {
     //
     // GPIO_B0
     //
+    pub gpio_b0_00: gpio::GPIO_B0_00<Alt5>,
+    pub gpio_b0_01: gpio::GPIO_B0_01<Alt5>,
+    pub gpio_b0_02: gpio::GPIO_B0_02<Alt5>,
     pub gpio_b0_03: gpio::GPIO_B0_03<Alt5>,
     pub gpio_b0_10: gpio::GPIO_B0_10<Alt5>,
     pub gpio_b0_11: gpio::GPIO_B0_11<Alt5>,
@@ -53,6 +56,8 @@ pub struct IOMUXC {
     //
     // GPIO_AD_B0
     //
+    pub gpio_ad_b0_00: gpio::GPIO_AD_B0_00<Alt5>,
+    pub gpio_ad_b0_01: gpio::GPIO_AD_B0_01<Alt5>,
     pub gpio_ad_b0_02: gpio::GPIO_AD_B0_02<Alt5>,
     pub gpio_ad_b0_03: gpio::GPIO_AD_B0_03<Alt5>,
     pub gpio_ad_b0_12: gpio::GPIO_AD_B0_12<Alt5>,
@@ -66,6 +71,8 @@ pub struct IOMUXC {
     pub gpio_ad_b1_03: gpio::GPIO_AD_B1_03<Alt5>,
     pub gpio_ad_b1_06: gpio::GPIO_AD_B1_06<Alt5>,
     pub gpio_ad_b1_07: gpio::GPIO_AD_B1_07<Alt5>,
+    pub gpio_ad_b1_08: gpio::GPIO_AD_B1_08<Alt5>,
+    pub gpio_ad_b1_09: gpio::GPIO_AD_B1_09<Alt5>,
     pub gpio_ad_b1_10: gpio::GPIO_AD_B1_10<Alt5>,
     pub gpio_ad_b1_11: gpio::GPIO_AD_B1_11<Alt5>,
     //
@@ -97,6 +104,9 @@ impl IOMUXC {
             //
             // GPIO_B0
             //
+            gpio_b0_00: gpio::GPIO_B0_00::new(),
+            gpio_b0_01: gpio::GPIO_B0_01::new(),
+            gpio_b0_02: gpio::GPIO_B0_02::new(),
             gpio_b0_03: gpio::GPIO_B0_03::new(),
             gpio_b0_10: gpio::GPIO_B0_10::new(),
             gpio_b0_11: gpio::GPIO_B0_11::new(),
@@ -108,6 +118,8 @@ impl IOMUXC {
             //
             // GPIO_AD_B0
             //
+            gpio_ad_b0_00: gpio::GPIO_AD_B0_00::new(),
+            gpio_ad_b0_01: gpio::GPIO_AD_B0_01::new(),
             gpio_ad_b0_02: gpio::GPIO_AD_B0_02::new(),
             gpio_ad_b0_03: gpio::GPIO_AD_B0_03::new(),
             gpio_ad_b0_12: gpio::GPIO_AD_B0_12::new(),
@@ -121,6 +133,8 @@ impl IOMUXC {
             gpio_ad_b1_03: gpio::GPIO_AD_B1_03::new(),
             gpio_ad_b1_06: gpio::GPIO_AD_B1_06::new(),
             gpio_ad_b1_07: gpio::GPIO_AD_B1_07::new(),
+            gpio_ad_b1_08: gpio::GPIO_AD_B1_08::new(),
+            gpio_ad_b1_09: gpio::GPIO_AD_B1_09::new(),
             gpio_ad_b1_10: gpio::GPIO_AD_B1_10::new(),
             gpio_ad_b1_11: gpio::GPIO_AD_B1_11::new(),
             //
@@ -148,7 +162,10 @@ impl IOMUXC {
 pub struct GPR(());
 
 impl GPR {
-    pub(crate) fn GPR27(&mut self) -> &crate::ral::RWRegister<u32> {
+    pub(crate) fn gpr26(&mut self) -> &crate::ral::RWRegister<u32> {
+        unsafe { &(*crate::ral::iomuxc_gpr::IOMUXC_GPR).GPR26 }
+    }
+    pub(crate) fn gpr27(&mut self) -> &crate::ral::RWRegister<u32> {
         unsafe { &(*crate::ral::iomuxc_gpr::IOMUXC_GPR).GPR27 }
     }
 }

--- a/imxrt-hal/src/iomuxc/gpio.rs
+++ b/imxrt-hal/src/iomuxc/gpio.rs
@@ -21,3 +21,6 @@ pub use emc::*;
 
 mod sd_b0;
 pub use sd_b0::*;
+
+mod sd_b1;
+pub use sd_b1::*;

--- a/imxrt-hal/src/iomuxc/gpio/ad_b1.rs
+++ b/imxrt-hal/src/iomuxc/gpio/ad_b1.rs
@@ -35,6 +35,18 @@ pad!(
 );
 
 pad!(
+    GPIO_AD_B1_08,
+    SW_MUX_CTL_PAD_GPIO_AD_B1_08,
+    [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt9]
+);
+
+pad!(
+    GPIO_AD_B1_09,
+    SW_MUX_CTL_PAD_GPIO_AD_B1_09,
+    [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt9]
+);
+
+pad!(
     GPIO_AD_B1_10,
     SW_MUX_CTL_PAD_GPIO_AD_B1_10,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt7, alt8, alt9]

--- a/imxrt-hal/src/iomuxc/gpio/b0.rs
+++ b/imxrt-hal/src/iomuxc/gpio/b0.rs
@@ -9,6 +9,11 @@ pad!(
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
 );
 pad!(
+    GPIO_B0_02,
+    SW_MUX_CTL_PAD_GPIO_B0_02,
+    [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]
+);
+pad!(
     GPIO_B0_03,
     SW_MUX_CTL_PAD_GPIO_B0_03,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8]

--- a/imxrt-hal/src/iomuxc/gpio/emc.rs
+++ b/imxrt-hal/src/iomuxc/gpio/emc.rs
@@ -29,6 +29,12 @@ pad!(
 );
 
 pad!(
+    GPIO_EMC_30,
+    SW_MUX_CTL_PAD_GPIO_EMC_30,
+    [alt0, alt1, alt2, alt3, alt4, alt5, alt8]
+);
+
+pad!(
     GPIO_EMC_31,
     SW_MUX_CTL_PAD_GPIO_EMC_31,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt8]

--- a/imxrt-hal/src/iomuxc/gpio/sd_b0.rs
+++ b/imxrt-hal/src/iomuxc/gpio/sd_b0.rs
@@ -11,3 +11,15 @@ pad!(
     SW_MUX_CTL_PAD_GPIO_SD_B0_01,
     [alt0, alt1, alt2, alt3, alt4, alt5, alt6, alt8, alt9]
 );
+
+pad!(
+    GPIO_SD_B0_02,
+    SW_MUX_CTL_PAD_GPIO_SD_B0_02,
+    [alt0, alt1, alt2, alt3, alt4, alt5, alt8, alt9]
+);
+
+pad!(
+    GPIO_SD_B0_03,
+    SW_MUX_CTL_PAD_GPIO_SD_B0_03,
+    [alt0, alt1, alt2, alt3, alt4, alt5, alt8, alt9]
+);

--- a/imxrt-hal/src/iomuxc/gpio/sd_b1.rs
+++ b/imxrt-hal/src/iomuxc/gpio/sd_b1.rs
@@ -1,0 +1,23 @@
+pad!(
+    GPIO_SD_B1_06,
+    SW_MUX_CTL_PAD_GPIO_SD_B1_06,
+    [alt0, alt1, alt2, alt3, alt4, alt5, alt8]
+);
+
+pad!(
+    GPIO_SD_B1_07,
+    SW_MUX_CTL_PAD_GPIO_SD_B1_07,
+    [alt0, alt1, alt2, alt3, alt4, alt5]
+);
+
+pad!(
+    GPIO_SD_B1_08,
+    SW_MUX_CTL_PAD_GPIO_SD_B1_08,
+    [alt0, alt1, alt2, alt3, alt4, alt5, alt6]
+);
+
+pad!(
+    GPIO_SD_B1_09,
+    SW_MUX_CTL_PAD_GPIO_SD_B1_09,
+    [alt0, alt1, alt2, alt3, alt4, alt5]
+);


### PR DESCRIPTION
The PR ports GPIO additions from the `teensy4-rs` project. In mciantyre/teensy4-rs#47, we added additional GPIOs to support SPI master devices. This PR accounts for part of #9.

I'm targeting the existing `hal_gpio` branch. If accepted, we can add the safety as discussed in #22 in `hal_gpio`, then merge everything into `master`.