### PR TITLE
Enable clippy in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,3 +59,5 @@ jobs:
       run: cd imxrt-hal && cargo test --verbose --features ${{ matrix.feature }}
     - name: Check format (${{ matrix.feature }}) for HAL
       run: cd imxrt-hal && cargo fmt --all -- --check
+    - name: Run clippy (${{ matrix.feature }}) for HAL
+      run: cd imxrt-hal && cargo clippy --features ${{ matrix.feature }} -- -D warnings

--- a/imxrt-hal/src/gpio.rs
+++ b/imxrt-hal/src/gpio.rs
@@ -20,47 +20,47 @@ pub trait IntoGpio {
 
 #[doc(hidden)]
 pub trait IntoRegister {
-    unsafe fn into_reg() -> *const crate::ral::gpio::RegisterBlock;
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock;
 }
 
 impl IntoRegister for GPIO1 {
-    unsafe fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
         crate::ral::gpio::GPIO1
     }
 }
 
 impl IntoRegister for GPIO2 {
-    unsafe fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
         crate::ral::gpio::GPIO2
     }
 }
 
 impl IntoRegister for GPIO3 {
-    unsafe fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
         crate::ral::gpio::GPIO3
     }
 }
 
 impl IntoRegister for GPIO4 {
-    unsafe fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
         crate::ral::gpio::GPIO4
     }
 }
 
 impl IntoRegister for GPIO5 {
-    unsafe fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
         crate::ral::gpio::GPIO5
     }
 }
 
 impl IntoRegister for GPIO6 {
-    unsafe fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
         crate::ral::gpio::GPIO6
     }
 }
 
 impl IntoRegister for GPIO7 {
-    unsafe fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
+    fn into_reg() -> *const crate::ral::gpio::RegisterBlock {
         crate::ral::gpio::GPIO7
     }
 }

--- a/imxrt-hal/src/i2c.rs
+++ b/imxrt-hal/src/i2c.rs
@@ -162,9 +162,9 @@ impl ClockSpeed {
             let error = cmp::max(computed_rate, baud_rate) - cmp::min(computed_rate, baud_rate);
             ByError {
                 prescalar: divider.saturating_sub(1).count_ones(),
-                clkhi: clkhi, /* (1..32) in u8 range */
-                error: error,
-                computed_rate: computed_rate,
+                clkhi, /* (1..32) in u8 range */
+                error,
+                computed_rate,
             }
         });
 

--- a/imxrt-ral/imxrtral.py
+++ b/imxrt-ral/imxrtral.py
@@ -38,6 +38,7 @@ CRATE_LIB_PREAMBLE = """\
 //! for example usage.
 
 #![no_std]
+#![allow(clippy::all)]
 
 mod register;
 


### PR DESCRIPTION
The PR enables `clippy` in CI. It asserts that there are no `clippy` warnings or errors in the HAL. The PR also cleans up existing `clippy` warnings.

#34 added automated builds and code formatting checks. It did not include a check for `clippy` issues. #35 notes that we can't immediately use the `actions-rs/clippy` GitHub action, since we don't have a working directory for the RAL. I propose that we run `clippy` even if we cannot realize the output in a GitHub UI. The output provided by the job is still actionable.

I structured the commits to show that [the CI flow will catch clippy issues in the HAL](https://github.com/mciantyre/imxrt-rs/runs/543625866).

Closes #35.