### PR TITLE
EVK1060 Pads

### DIFF
--- a/imxrt-hal/src/gpio.rs
+++ b/imxrt-hal/src/gpio.rs
@@ -236,7 +236,18 @@ ios! {
     17, GPIO1IO17: [GPIO1, gpio17, crate::iomuxc::gpio::GPIO_AD_B1_01<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
     18, GPIO1IO18: [GPIO1, gpio18, crate::iomuxc::gpio::GPIO_AD_B1_02<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
     19, GPIO1IO19: [GPIO1, gpio19, crate::iomuxc::gpio::GPIO_AD_B1_03<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
-    // TODO: more from this bank? Missing 20..=31
+    20, GPIO1IO20: [GPIO1, gpio20, crate::iomuxc::gpio::GPIO_AD_B1_04<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    21, GPIO1IO21: [GPIO1, gpio21, crate::iomuxc::gpio::GPIO_AD_B1_05<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    22, GPIO1IO22: [GPIO1, gpio22, crate::iomuxc::gpio::GPIO_AD_B1_06<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    23, GPIO1IO23: [GPIO1, gpio23, crate::iomuxc::gpio::GPIO_AD_B1_07<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    24, GPIO1IO24: [GPIO1, gpio24, crate::iomuxc::gpio::GPIO_AD_B1_08<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    25, GPIO1IO25: [GPIO1, gpio25, crate::iomuxc::gpio::GPIO_AD_B1_09<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    26, GPIO1IO26: [GPIO1, gpio26, crate::iomuxc::gpio::GPIO_AD_B1_10<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    27, GPIO1IO27: [GPIO1, gpio27, crate::iomuxc::gpio::GPIO_AD_B1_11<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    28, GPIO1IO28: [GPIO1, gpio28, crate::iomuxc::gpio::GPIO_AD_B1_12<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    29, GPIO1IO29: [GPIO1, gpio29, crate::iomuxc::gpio::GPIO_AD_B1_13<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    30, GPIO1IO30: [GPIO1, gpio30, crate::iomuxc::gpio::GPIO_AD_B1_14<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
+    31, GPIO1IO31: [GPIO1, gpio31, crate::iomuxc::gpio::GPIO_AD_B1_15<crate::iomuxc::Alt5>, FAST: (GPIO6, gpr26)],
 }
 
 // Bank 2

--- a/imxrt-hal/src/iomuxc.rs
+++ b/imxrt-hal/src/iomuxc.rs
@@ -47,11 +47,13 @@ pub struct IOMUXC {
     pub gpio_b0_03: gpio::GPIO_B0_03<Alt5>,
     pub gpio_b0_10: gpio::GPIO_B0_10<Alt5>,
     pub gpio_b0_11: gpio::GPIO_B0_11<Alt5>,
+
     //
     // GPIO_B1
     //
     pub gpio_b1_00: gpio::GPIO_B1_00<Alt5>,
     pub gpio_b1_01: gpio::GPIO_B1_01<Alt5>,
+
     //
     // GPIO_AD_B0
     //
@@ -59,8 +61,23 @@ pub struct IOMUXC {
     pub gpio_ad_b0_01: gpio::GPIO_AD_B0_01<Alt5>,
     pub gpio_ad_b0_02: gpio::GPIO_AD_B0_02<Alt5>,
     pub gpio_ad_b0_03: gpio::GPIO_AD_B0_03<Alt5>,
+
+    // Note that these pads default to Alt0 rather than Alt5
+    // as described in the reference manual in section 11.7
+    pub gpio_ad_b0_04: gpio::GPIO_AD_B0_04<Alt0>,
+    pub gpio_ad_b0_05: gpio::GPIO_AD_B0_05<Alt0>,
+    pub gpio_ad_b0_06: gpio::GPIO_AD_B0_06<Alt0>,
+    pub gpio_ad_b0_07: gpio::GPIO_AD_B0_07<Alt0>,
+    pub gpio_ad_b0_08: gpio::GPIO_AD_B0_08<Alt0>,
+    pub gpio_ad_b0_09: gpio::GPIO_AD_B0_09<Alt0>,
+    pub gpio_ad_b0_10: gpio::GPIO_AD_B0_10<Alt0>,
+    pub gpio_ad_b0_11: gpio::GPIO_AD_B0_11<Alt0>,
+
     pub gpio_ad_b0_12: gpio::GPIO_AD_B0_12<Alt5>,
     pub gpio_ad_b0_13: gpio::GPIO_AD_B0_13<Alt5>,
+    pub gpio_ad_b0_14: gpio::GPIO_AD_B0_14<Alt5>,
+    pub gpio_ad_b0_15: gpio::GPIO_AD_B0_15<Alt5>,
+
     //
     // GPIO_AD_B1
     //
@@ -68,17 +85,27 @@ pub struct IOMUXC {
     pub gpio_ad_b1_01: gpio::GPIO_AD_B1_01<Alt5>,
     pub gpio_ad_b1_02: gpio::GPIO_AD_B1_02<Alt5>,
     pub gpio_ad_b1_03: gpio::GPIO_AD_B1_03<Alt5>,
+    pub gpio_ad_b1_04: gpio::GPIO_AD_B1_04<Alt5>,
+    pub gpio_ad_b1_05: gpio::GPIO_AD_B1_05<Alt5>,
     pub gpio_ad_b1_06: gpio::GPIO_AD_B1_06<Alt5>,
     pub gpio_ad_b1_07: gpio::GPIO_AD_B1_07<Alt5>,
     pub gpio_ad_b1_08: gpio::GPIO_AD_B1_08<Alt5>,
     pub gpio_ad_b1_09: gpio::GPIO_AD_B1_09<Alt5>,
     pub gpio_ad_b1_10: gpio::GPIO_AD_B1_10<Alt5>,
     pub gpio_ad_b1_11: gpio::GPIO_AD_B1_11<Alt5>,
+    pub gpio_ad_b1_12: gpio::GPIO_AD_B1_12<Alt5>,
+    pub gpio_ad_b1_13: gpio::GPIO_AD_B1_13<Alt5>,
+    pub gpio_ad_b1_14: gpio::GPIO_AD_B1_14<Alt5>,
+    pub gpio_ad_b1_15: gpio::GPIO_AD_B1_15<Alt5>,
+
     //
     // GPIO_SD_B0
     //
     pub gpio_sd_b0_00: gpio::GPIO_SD_B0_00<Alt5>,
     pub gpio_sd_b0_01: gpio::GPIO_SD_B0_01<Alt5>,
+    pub gpio_sd_b0_02: gpio::GPIO_SD_B0_02<Alt5>,
+    pub gpio_sd_b0_03: gpio::GPIO_SD_B0_03<Alt5>,
+
     //
     // GPIO_EMC
     //
@@ -112,11 +139,13 @@ impl IOMUXC {
             gpio_b0_03: gpio::GPIO_B0_03::new(),
             gpio_b0_10: gpio::GPIO_B0_10::new(),
             gpio_b0_11: gpio::GPIO_B0_11::new(),
+
             //
             // GPIO_B1
             //
             gpio_b1_00: gpio::GPIO_B1_00::new(),
             gpio_b1_01: gpio::GPIO_B1_01::new(),
+
             //
             // GPIO_AD_B0
             //
@@ -124,8 +153,19 @@ impl IOMUXC {
             gpio_ad_b0_01: gpio::GPIO_AD_B0_01::new(),
             gpio_ad_b0_02: gpio::GPIO_AD_B0_02::new(),
             gpio_ad_b0_03: gpio::GPIO_AD_B0_03::new(),
+            gpio_ad_b0_04: gpio::GPIO_AD_B0_04::new(),
+            gpio_ad_b0_05: gpio::GPIO_AD_B0_05::new(),
+            gpio_ad_b0_06: gpio::GPIO_AD_B0_06::new(),
+            gpio_ad_b0_07: gpio::GPIO_AD_B0_07::new(),
+            gpio_ad_b0_08: gpio::GPIO_AD_B0_08::new(),
+            gpio_ad_b0_09: gpio::GPIO_AD_B0_09::new(),
+            gpio_ad_b0_10: gpio::GPIO_AD_B0_10::new(),
+            gpio_ad_b0_11: gpio::GPIO_AD_B0_11::new(),
             gpio_ad_b0_12: gpio::GPIO_AD_B0_12::new(),
             gpio_ad_b0_13: gpio::GPIO_AD_B0_13::new(),
+            gpio_ad_b0_14: gpio::GPIO_AD_B0_14::new(),
+            gpio_ad_b0_15: gpio::GPIO_AD_B0_15::new(),
+
             //
             // GPIO_AD_B1
             //
@@ -133,17 +173,27 @@ impl IOMUXC {
             gpio_ad_b1_01: gpio::GPIO_AD_B1_01::new(),
             gpio_ad_b1_02: gpio::GPIO_AD_B1_02::new(),
             gpio_ad_b1_03: gpio::GPIO_AD_B1_03::new(),
+            gpio_ad_b1_04: gpio::GPIO_AD_B1_04::new(),
+            gpio_ad_b1_05: gpio::GPIO_AD_B1_05::new(),
             gpio_ad_b1_06: gpio::GPIO_AD_B1_06::new(),
             gpio_ad_b1_07: gpio::GPIO_AD_B1_07::new(),
             gpio_ad_b1_08: gpio::GPIO_AD_B1_08::new(),
             gpio_ad_b1_09: gpio::GPIO_AD_B1_09::new(),
             gpio_ad_b1_10: gpio::GPIO_AD_B1_10::new(),
             gpio_ad_b1_11: gpio::GPIO_AD_B1_11::new(),
+            gpio_ad_b1_12: gpio::GPIO_AD_B1_12::new(),
+            gpio_ad_b1_13: gpio::GPIO_AD_B1_13::new(),
+            gpio_ad_b1_14: gpio::GPIO_AD_B1_14::new(),
+            gpio_ad_b1_15: gpio::GPIO_AD_B1_15::new(),
+
             //
             // GPIO_SD_B0
             //
             gpio_sd_b0_00: gpio::GPIO_SD_B0_00::new(),
             gpio_sd_b0_01: gpio::GPIO_SD_B0_01::new(),
+            gpio_sd_b0_02: gpio::GPIO_SD_B0_02::new(),
+            gpio_sd_b0_03: gpio::GPIO_SD_B0_03::new(),
+
             //
             // GPIO_EMC
             //


### PR DESCRIPTION
Adds some needed pad definitions to make the 1060evk arduino header usable.

Depends on the pin_config branch being merged first