### PR TITLE
Add derives for UART ReadError

### DIFF
--- a/imxrt-hal/src/uart.rs
+++ b/imxrt-hal/src/uart.rs
@@ -453,6 +453,7 @@ bitflags::bitflags! {
 }
 
 /// Type that describes a read error
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReadError {
     /// Decribes the reason for the error
     pub flags: ReadErrorFlags,


### PR DESCRIPTION
Copied from I2C's error type, without `Copy` as this error is more complex. Both `ReadErrorFlags` and `u8` are `Copy`, though, if that's desired.