### PR TITLE
Add general purpose timers

### DIFF
--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 ### Added
 
-- The iMXRT's general purpose timers (GPT) are now available. The timers do not implement any of the `embedded_hal`
-  traits at this time. However, the timers are suitable for generating interrupts on repeated durations. See the
-  module-level docs for more information and TODOs.
+- The iMXRT's general purpose timers (GPT) are now available.
 
 ### Changed
 

--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- The iMXRT's general purpose timers (GPT) are now available. The timers do not implement any of the `embedded_hal`
+  traits at this time. However, the timers are suitable for generating interrupts on repeated durations. See the
+  module-level docs for more information and TODOs.
+
+### Changed
+
+- `imxrt_hal::pit::Unclocked::clock` now takes a `&mut imxrt_hal::ccm::perclk::Configured` mutable reference, rather
+  than a value. Users need to add a `&mut` qualifier to the `clock()` argument, and qualify the `Configured`
+  object as `mut` to migrate their code. The object may now be shared between PIT and GPT clocking methods.
+
+Prior releases were not tracked with a changelog entry.
+
+[Unreleased]: https://github.com/imxrt-rs/imxrt-rt/compare/v0.2.1...HEAD

--- a/imxrt-hal/src/gpt.rs
+++ b/imxrt-hal/src/gpt.rs
@@ -1,0 +1,236 @@
+//! General Purpose Timer (GPT)
+//!
+//! ## Features
+//!
+//! The GPTs are count-up timers that run off of the IPG
+//! clock or the crystal oscillator (24MHz). Each GPT has
+//! three compare registers. When the counter reaches a
+//! value in a compare register, the GPT signals the comparison.
+//! A comparison can generate an interrupt.
+//!
+//! ## TODO
+//!
+//! - Input capture. Each GPT can capture the value of the counter
+//!   when a pin state changes. When the pin state changes, the
+//!   GPT can generate an interrupt.
+//! - Output generation. When one of the three comparison registers
+//!   match the counter, the GPT can generate a signal on an output
+//!   pin.
+
+use crate::{
+    ccm::{perclk, ticks},
+    ral,
+};
+
+use core::time::Duration;
+
+/// An unclocked GPT
+///
+/// Each GPT starts in an unclocked state. By supplying
+/// a proper clock configuration, the GPT will clock
+/// itself and prepare for operation.
+pub struct Unclocked {
+    registers: ral::gpt::Instance,
+    instance: Instance,
+}
+
+/// GPT instance
+///
+/// Used for runtime selection of GPT-specific configurations
+enum Instance {
+    One,
+    Two,
+}
+
+/// Prescaler applied to each GPT's input clock.
+///
+/// See comments at usage for justification.
+const DEFAULT_PRESCALER: u32 = 2;
+
+/// A general purpose timer
+///
+/// The timers support three output compare registers. When a compare register
+/// matches the value of the counter, the GPT may trigger an interrupt.
+///
+/// By default, the timer runs in wait mode.
+pub struct GPT {
+    registers: ral::gpt::Instance,
+    clock_hz: u32,
+}
+
+impl Unclocked {
+    /// Create an unclocked GPT1
+    pub(crate) fn one(registers: ral::gpt::Instance) -> Self {
+        Unclocked {
+            registers,
+            instance: Instance::One,
+        }
+    }
+
+    /// Create an unclocked GPT2
+    pub(crate) fn two(registers: ral::gpt::Instance) -> Self {
+        Unclocked {
+            registers,
+            instance: Instance::Two,
+        }
+    }
+
+    /// Enable the clocks to the GPT, returning a GPT timer
+    ///
+    /// `configured` is a handle describing the clocks and clock
+    /// configuration for the GPT. See the `ccm` module for more
+    /// information.
+    pub fn clock(self, configured: &mut perclk::Configured) -> GPT {
+        let (freq, div) = match self.instance {
+            Instance::One => configured.enable_gpt1_clock_gates(),
+            Instance::Two => configured.enable_gpt2_clock_gates(),
+        };
+
+        match configured.clock_selection() {
+            perclk::CLKSEL::OSC => {
+                ral::write_reg!(
+                    ral::gpt,
+                    self.registers,
+                    CR,
+                    EN_24M: 1, // Enable crystal oscillator
+                    CLKSRC: 0b101, // Crystal Oscillator
+                    FRR: 1, // Channel 1 doesn't reset the counter on trigger
+                    WAITEN: 1 // Run GPT in wait mode
+                );
+                // The 24MHz prescaler register can't be non-zero. Not sure why.
+                // So, this means that there's a divider of 2 when using the
+                // crystal oscillator.
+                ral::write_reg!(ral::gpt, self.registers, PR, PRESCALER24M: (DEFAULT_PRESCALER - 1));
+            }
+            perclk::CLKSEL::IPG(_) => {
+                ral::write_reg!(
+                    ral::gpt,
+                    self.registers,
+                    CR,
+                    EN_24M: 0, // No crystal oscillator
+                    CLKSRC: 0b001, // Peripheral Clock
+                    FRR: 1, // Channel 1 doesn't reset the counter on trigger
+                    WAITEN: 1 // Run GPT in wait mode
+                );
+                // See the above comment about needing a prescaler for the other
+                // clock. This is for consistency, so that we can implement the
+                // "divide by two" behavior.
+                ral::write_reg!(ral::gpt, self.registers, PR, PRESCALER: (DEFAULT_PRESCALER - 1));
+            }
+        }
+
+        // Clear all statuses
+        ral::write_reg!(ral::gpt, self.registers, SR, 0b11_1111);
+
+        let clock_hz = (freq / div).0;
+
+        GPT {
+            registers: self.registers,
+            clock_hz,
+        }
+    }
+}
+
+/// An output compare register indication
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum OutputCompareRegister {
+    One,
+    Two,
+    Three,
+}
+
+impl GPT {
+    /// Enable or disable the GPT
+    ///
+    /// When enabled, the counter starts counting. When disabled, the counter will
+    /// stop counting.
+    pub fn set_enable(&mut self, enable: bool) {
+        ral::modify_reg!(ral::gpt, self.registers, CR, EN: (enable as u32));
+    }
+
+    /// Indicates if the GPT is enabled (`true`) or disabled (`false`).
+    pub fn is_enabled(&self) -> bool {
+        ral::read_reg!(ral::gpt, self.registers, CR, EN == 1)
+    }
+
+    /// Allow the GPT to run in wait mode; or, prevent the GPT from running
+    /// in wait mode.
+    pub fn set_wait_mode_enable(&mut self, wait: bool) {
+        ral::modify_reg!(ral::gpt, self.registers, CR, WAITEN: (wait as u32));
+    }
+
+    /// Indicates if the GPT runs while in wait mode
+    pub fn is_wait_mode_enabled(&self) -> bool {
+        ral::read_reg!(ral::gpt, self.registers, CR, WAITEN == 1)
+    }
+
+    /// Enable the GPT interrupt when the output compares
+    pub fn set_interrupt_on_compare(&mut self, output: OutputCompareRegister, intr: bool) {
+        let ir: u32 = ral::read_reg!(ral::gpt, self.registers, IR);
+        let ir: u32 = if intr {
+            ir | (1 << (output as u32))
+        } else {
+            ir & !(1 << (output as u32))
+        };
+        ral::write_reg!(ral::gpt, self.registers, IR, ir);
+    }
+
+    /// Returns the current count of the GPT
+    pub fn count(&self) -> u32 {
+        ral::read_reg!(ral::gpt, self.registers, CNT)
+    }
+
+    /// Set an output compare register to trigger on the next `count` value of the
+    /// counter.
+    fn set_output_compare_count(&mut self, output: OutputCompareRegister, count: u32) {
+        match output {
+            OutputCompareRegister::One => ral::write_reg!(ral::gpt, self.registers, OCR1, count),
+            OutputCompareRegister::Two => ral::write_reg!(ral::gpt, self.registers, OCR2, count),
+            OutputCompareRegister::Three => ral::write_reg!(ral::gpt, self.registers, OCR3, count),
+        }
+    }
+
+    /// Set an output compare register to trigger when the specified duration elapses
+    ///
+    /// This requires a read of the counter, then a conversion of the duration of the duration
+    /// to a count value, then a write to the correct register. If the GPT is currently
+    /// enabled, and the duration is small, this could miss the comparison until the counter
+    /// wraps. Consider disabling the GPT before setting a wait duration.
+    pub fn set_output_compare_duration(
+        &mut self,
+        output: OutputCompareRegister,
+        duration: Duration,
+    ) {
+        let tics: u32 =
+            ticks(duration, self.clock_hz, DEFAULT_PRESCALER).unwrap_or(u32::max_value());
+        let next_count = self.count().wrapping_add(tics);
+        self.set_output_compare_count(output, next_count);
+    }
+
+    /// Returns a handle that can query and modify the output compare status for the provided output
+    pub fn output_compare_status(&mut self, output: OutputCompareRegister) -> OutputCompareStatus {
+        OutputCompareStatus { gpt: self, output }
+    }
+}
+
+/// A handle to evaluate and modify the output compare status
+pub struct OutputCompareStatus<'a> {
+    gpt: &'a mut GPT,
+    output: OutputCompareRegister,
+}
+
+impl<'a> OutputCompareStatus<'a> {
+    /// Returns true if this output compare has triggered
+    pub fn is_set(&self) -> bool {
+        let sr = ral::read_reg!(ral::gpt, self.gpt.registers, SR);
+        sr & (1 << (self.output as u32)) != 0
+    }
+
+    /// Clear the output compare status flag
+    ///
+    /// It's necessary to clear the flag when the comparison has triggered
+    /// an interrupt.
+    pub fn clear(&mut self) {
+        ral::write_reg!(ral::gpt, self.gpt.registers, SR, 1 << (self.output as u32));
+    }
+}

--- a/imxrt-hal/src/gpt.rs
+++ b/imxrt-hal/src/gpt.rs
@@ -8,6 +8,10 @@
 //! value in a compare register, the GPT signals the comparison.
 //! A comparison can generate an interrupt.
 //!
+//! GPTs, by default, are not enabled in wait mode. Use
+//! [`set_wait_mode_enable(true)`](struct.GPT.html#method.set_wait_mode_enable)
+//! to enable GPTs in wait mode.
+//!
 //! Use GPTs to
 //!
 //! - detect if a timing interval has elapsed
@@ -105,10 +109,11 @@ impl Unclocked {
                     CR,
                     EN_24M: 1, // Enable crystal oscillator
                     CLKSRC: 0b101, // Crystal Oscillator
-                    FRR: 1, // Channel 1 doesn't reset the counter on trigger
-                    WAITEN: 1 // Run GPT in wait mode
+                    FRR: 1 // Channel 1 doesn't reset the counter on trigger
                 );
                 // The 24MHz prescaler register can't be non-zero. Not sure why.
+                // The reference manual says its OK, but it doesn't work. The
+                // se4L project noted the same issue in their kernel.
                 // So, this means that there's a divider of 2 when using the
                 // crystal oscillator.
                 ral::write_reg!(ral::gpt, self.registers, PR, PRESCALER24M: (DEFAULT_PRESCALER - 1));
@@ -120,8 +125,7 @@ impl Unclocked {
                     CR,
                     EN_24M: 0, // No crystal oscillator
                     CLKSRC: 0b001, // Peripheral Clock
-                    FRR: 1, // Channel 1 doesn't reset the counter on trigger
-                    WAITEN: 1 // Run GPT in wait mode
+                    FRR: 1 // Channel 1 doesn't reset the counter on trigger
                 );
                 // See the above comment about needing a prescaler for the other
                 // clock. This is for consistency, so that we can implement the

--- a/imxrt-hal/src/lib.rs
+++ b/imxrt-hal/src/lib.rs
@@ -20,6 +20,7 @@ pub use imxrt_ral as ral;
 
 pub mod ccm;
 pub mod gpio;
+pub mod gpt;
 pub mod i2c;
 pub mod iomuxc;
 pub mod pit;
@@ -49,6 +50,8 @@ pub struct Peripherals {
     pub i2c: i2c::Unclocked,
     pub uart: uart::Unclocked,
     pub spi: spi::Unclocked,
+    pub gpt1: gpt::Unclocked,
+    pub gpt2: gpt::Unclocked,
 }
 
 impl Peripherals {
@@ -84,6 +87,8 @@ impl Peripherals {
                 spi3: ral::lpspi::LPSPI3::take()?,
                 spi4: ral::lpspi::LPSPI4::take()?,
             },
+            gpt1: gpt::Unclocked::one(ral::gpt::GPT1::take()?),
+            gpt2: gpt::Unclocked::two(ral::gpt::GPT2::take()?),
         };
         Some(p)
     }

--- a/imxrt-hal/src/pit.rs
+++ b/imxrt-hal/src/pit.rs
@@ -20,14 +20,14 @@ impl UnclockedPIT {
     /// module.
     pub fn clock(
         self,
-        configured: perclk::Configured,
+        configured: &mut perclk::Configured,
     ) -> (
         PIT<channel::_0>,
         PIT<channel::_1>,
         PIT<channel::_2>,
         PIT<channel::_3>,
     ) {
-        let (clock_hz, divider) = configured.enable();
+        let (clock_hz, divider) = configured.enable_pit_clock_gates();
         ral::write_reg!(ral::pit, self.0, MCR, MDIS: MDIS_0);
         // Intentionally dropping the ral::pit::Instance. We will give consumers
         // the appearance that we own it so that they cannot subsequently take it.


### PR DESCRIPTION
The PR adds general purpose timers (GPT) to the HAL. They're similar to the periodic interrupt timers (PIT), but more general. Users can also support multiple timers from a single GPT instance, rather than having multiple PIT objects to manage. `GPT`s implement the traits of the `embedded_hal::timer` module. The GPTs are nifty if you need a counter that wraps around; PITs don't support wrap-around.

The PR introduces a breaking change in the way we configure PIT clocks. I've described the change in the HAL's new changelog.

There's GPT examples in the `teensy4-rs` project.

- `gpt.rs` shows how we can [use a `GPT` to generate interrupts](https://github.com/mciantyre/teensy4-rs/blob/c46be85d8a636337e360c3e05e55b7b8af5834d8/teensy4-examples/src/gpt.rs)
- The updated `timer.rs` shows how to [use a `GPT` to measure execution time.](https://github.com/mciantyre/teensy4-rs/blob/c46be85d8a636337e360c3e05e55b7b8af5834d8/teensy4-examples/src/timer.rs)