### PR TITLE
Add development instructions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ i.MX RT register access layer, hardware abstraction layer, and svd patches.
 This is very much modeled on the great stm32ral and stm32-rs crates which do 
 much the same for ST's fantastic STM32 family.
 
+## Development
+
+- Clone this repository
+- Install the requirements: `pip3 install --user svdtools`
+- Make sure a `Cargo.toml` gets generated: `cd imxrt-ral; make; cd ..;`
+- After this, the cargo workspace should be set up and your editor's language server should work with this repository.
+
 ## Goals
 
 * Create *the* collaborative group to support using Rust on NXP's i.MX RT series.


### PR DESCRIPTION
Suggestion: add development instructions in the readme, to make contributing easier.
Let me know if there's more steps required!

Before running these steps, I wasn't able to run `cargo check` in the workspace:
```
cargo check
error: failed to read `/Users/walther/git/imxrt-rs/imxrt-ral/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
```

After these steps, I can run `cargo check`, but I get 8324 errors 😅 

[errors.txt](https://github.com/imxrt-rs/imxrt-rs/files/4533768/errors.txt)

```
error: aborting due to 8324 previous errors

Some errors have detailed explanations: E0425, E0432, E0433.
For more information about an error, try `rustc --explain E0425`.
error: could not compile `imxrt-hal`.
```