### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/cache@v1
       id: ral-cache
       with:
-        path: imxrt-ral/src
+        path: imxrt-ral
         key: ${{ runner.OS }}-ral-cache-${{ hashFiles('imxrt-ral/imxrtral.py') }}
     - name: Generate code
       if: steps.ral-cache.outputs.cache-hit != 'true'
@@ -48,7 +48,7 @@ jobs:
       uses: actions/cache@v1
       id: ral-cache
       with:
-        path: imxrt-ral/src
+        path: imxrt-ral
         key: ${{ runner.OS }}-ral-cache-${{ hashFiles('imxrt-ral/imxrtral.py') }}
     - name: Generate code
       if: steps.ral-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,21 +11,25 @@ jobs:
         feature: ["imxrt1011", "imxrt1015", "imxrt1021", "imxrt1051", "imxrt1052", "imxrt1061", "imxrt1062", "imxrt1064"]
     steps:
     - uses: actions/checkout@v2
-    - name: install virtualenv
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install python dependencies
-      run: cd imxrt-ral && pip install -U -r requirements.txt
     - name: Cache generated code
       uses: actions/cache@v1
       id: ral-cache
       with:
         path: imxrt-ral
         key: ${{ runner.OS }}-ral-cache-${{ hashFiles('imxrt-ral/imxrtral.py') }}
+    # These steps only run if we have a RAL cache miss.
+    - name: install virtualenv
+      if: steps.ral-cache.outputs.cache-hit != 'true'
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install python dependencies
+      if: steps.ral-cache.outputs.cache-hit != 'true'
+      run: cd imxrt-ral && pip install -U -r requirements.txt
     - name: Generate code
       if: steps.ral-cache.outputs.cache-hit != 'true'
       run: cd imxrt-ral && make
+    # Build and test the RAL
     - name: Build imxrt-ral for (${{ matrix.feature }}) RAL
       run: cd imxrt-ral && cargo build --verbose --features ${{ matrix.feature }}
     - name: Run tests (${{ matrix.feature }}) for RAL
@@ -38,21 +42,25 @@ jobs:
         feature: ["imxrt1062"]
     steps:
     - uses: actions/checkout@v2
-    - name: install virtualenv
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install python dependencies
-      run: cd imxrt-ral && pip install -U -r requirements.txt
     - name: Cache generated code
       uses: actions/cache@v1
       id: ral-cache
       with:
         path: imxrt-ral
         key: ${{ runner.OS }}-ral-cache-${{ hashFiles('imxrt-ral/imxrtral.py') }}
+    # These steps only run if we have a RAL cache miss
+    - name: install virtualenv
+      if: steps.ral-cache.outputs.cache-hit != 'true'
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install python dependencies
+      if: steps.ral-cache.outputs.cache-hit != 'true'
+      run: cd imxrt-ral && pip install -U -r requirements.txt
     - name: Generate code
       if: steps.ral-cache.outputs.cache-hit != 'true'
       run: cd imxrt-ral && make
+    # Build and test the HAL
     - name: Build imxrt-hal for (${{ matrix.feature }}) HAL
       run: cd imxrt-hal && cargo build --verbose --features ${{ matrix.feature }}
     - name: Run tests (${{ matrix.feature }}) for HAL

--- a/imxrt-ral/imxrtral.py
+++ b/imxrt-ral/imxrtral.py
@@ -4,7 +4,7 @@ imxrtral.py
 Copyright 2018 Adam Greig
 Copyright 2020 Tom Burdick
 
-Licensed under MIT and Apache 2.0, see LICENSE_MIT and LICENSE_APACHE.
+Licensed under MIT and Apache 2.0. See LICENSE_MIT and LICENSE_APACHE.
 """
 
 import os


### PR DESCRIPTION
The PR addresses issues with our CI builds. We excluded the RAL's `Cargo.toml` in #45, and we seem to regularly see CI build failures after that PR. The errors indicate that the system [can't find the RAL's `Cargo.toml`](https://github.com/imxrt-rs/imxrt-rs/runs/618287558), which we were expecting to be in VCS (example error in #51).

We now cache the entire `imxrt-ral` directory, not just the `imxrt-ral/src` Rust source files. This includes the RAL's `Cargo.toml` in the cache.

I also swapped some build steps. If we have a cache hit, we don't need to install the Python dependencies and set up the Python environments, since they're only necessary to build the RAL. It lets us skip two more steps for each cache hit.