### PR TITLE
Add module-level, compiler-checked examples

### DIFF
--- a/imxrt-hal/Cargo.toml
+++ b/imxrt-hal/Cargo.toml
@@ -41,3 +41,6 @@ imxrt1062 = ["imxrt-ral/imxrt1062"]
 rtfm = ["imxrt-ral/rtfm"]
 rt = ["imxrt-ral/rt"]
 nosync = ["imxrt-ral/nosync"]
+
+[package.metadata.docs.rs]
+features = ["imxrt1062"]

--- a/imxrt-hal/src/gpt.rs
+++ b/imxrt-hal/src/gpt.rs
@@ -84,6 +84,40 @@
 //! Although the adapters work on a single OCR, the timer may continue to monitor the
 //! other two OCRs.
 //!
+//! # Example
+//!
+//! ```no_run
+//! use imxrt_hal;
+//!
+//! let mut peripherals = imxrt_hal::Peripherals::take().unwrap();
+//!
+//! let (_, ipg_hz) = peripherals.ccm.pll1.set_arm_clock(
+//!     imxrt_hal::ccm::PLL1::ARM_HZ,
+//!     &mut peripherals.ccm.handle,
+//!     &mut peripherals.dcdc,
+//! );
+//!
+//! let mut cfg = peripherals.ccm.perclk.configure(
+//!     &mut peripherals.ccm.handle,
+//!     imxrt_hal::ccm::perclk::PODF::DIVIDE_3,
+//!     imxrt_hal::ccm::perclk::CLKSEL::IPG(ipg_hz),
+//! );
+//!
+//! let mut gpt1 = peripherals.gpt1.clock(&mut cfg);
+//!
+//! gpt1.set_output_interrupt_on_compare(
+//!     imxrt_hal::gpt::OutputCompareRegister::Three, 
+//!     true,
+//! );
+//! gpt1.set_wait_mode_enable(true);
+//! gpt1.set_mode(imxrt_hal::gpt::Mode::FreeRunning);
+//!
+//! gpt1.set_output_compare_duration(
+//!     imxrt_hal::gpt::OutputCompareRegister::Three,
+//!     core::time::Duration::from_micros(765),
+//! );
+//! ```
+//!
 //! # TODO
 //!
 //! - Input capture. Each GPT can capture the value of the counter

--- a/imxrt-hal/src/gpt.rs
+++ b/imxrt-hal/src/gpt.rs
@@ -106,7 +106,7 @@
 //! let mut gpt1 = peripherals.gpt1.clock(&mut cfg);
 //!
 //! gpt1.set_output_interrupt_on_compare(
-//!     imxrt_hal::gpt::OutputCompareRegister::Three, 
+//!     imxrt_hal::gpt::OutputCompareRegister::Three,
 //!     true,
 //! );
 //! gpt1.set_wait_mode_enable(true);

--- a/imxrt-hal/src/i2c.rs
+++ b/imxrt-hal/src/i2c.rs
@@ -27,7 +27,7 @@
 //! let mut input = [0; 3];
 //! let output = [0x74];
 //! # const MY_SLAVE_ADDRESS: u8 = 0;
-//! 
+//!
 //! i2c3.write_read(MY_SLAVE_ADDRESS, &output, &mut input).unwrap();
 //! ```
 

--- a/imxrt-hal/src/i2c.rs
+++ b/imxrt-hal/src/i2c.rs
@@ -1,4 +1,35 @@
 //! I2C support
+//!
+//! # Example
+//!
+//! ```no_run
+//! use imxrt_hal;
+//! use imxrt_hal::i2c::ClockSpeed;
+//! use embedded_hal::blocking::i2c::WriteRead;
+//!
+//! let mut peripherals = imxrt_hal::Peripherals::take().unwrap();
+//!
+//! let (_, _, i2c3_builder, _) = peripherals.i2c.clock(
+//!     &mut peripherals.ccm.handle,
+//!     imxrt_hal::ccm::i2c::ClockSelect::OSC, // 24MHz clock...
+//!     imxrt_hal::ccm::i2c::PrescalarSelect::DIVIDE_3, // Divide by 3
+//! );
+//!
+//! let mut i2c3 = i2c3_builder.build(
+//!     peripherals.iomuxc.gpio_ad_b1_07.alt1(),
+//!     peripherals.iomuxc.gpio_ad_b1_06.alt1(),
+//! );
+//!
+//! i2c3.set_bus_idle_timeout(core::time::Duration::from_micros(200)).unwrap();
+//! i2c3.set_pin_low_timeout(core::time::Duration::from_millis(1)).unwrap();
+//! i2c3.set_clock_speed(ClockSpeed::KHz400).unwrap();
+//!
+//! let mut input = [0; 3];
+//! let output = [0x74];
+//! # const MY_SLAVE_ADDRESS: u8 = 0;
+//! 
+//! i2c3.write_read(MY_SLAVE_ADDRESS, &output, &mut input).unwrap();
+//! ```
 
 pub use crate::iomuxc::i2c::module;
 

--- a/imxrt-hal/src/iomuxc.rs
+++ b/imxrt-hal/src/iomuxc.rs
@@ -1,34 +1,4 @@
 //! IOMUX Controller
-//!
-//! ## Configure pin settings
-//!
-//! This takes a given PinConfig and updates the *_PAD_MUX_PAD_*
-//! register related to a given Pin.
-//!
-//! If the PinConfig does not write to all fields, which is checked
-//! by PinConfig::is_modify() the config is applied as a
-//! modification to the current PAD_MUX_PAD register value.
-//!
-//! Otherwise the PAD_MUX_PAD register is overwritten with the new
-//! configuration.
-//!
-//! PinConfig docs supply more information on how to build a
-//! PinConfig and what typical defaults from the reference
-//! manual look like.
-//!
-//! # Example using const builder functions
-//!
-//! ```no_run
-//! use imxrt_hal::iomuxc::pin_config::*;
-//! use imxrt_hal::Peripherals;
-//!
-//! const LED_PIN_CONFIG: PinConfig = PinConfig::with_none()
-//!                      .set_pull_up(PullUp::PullUp_100KOhm)
-//!                      .set_speed(Speed::Speed2_150MHz)
-//!                      .set_drive_strength(DriveStrength::R0_DIV_6);
-//! let mut peripherals = Peripherals::take().unwrap();
-//! peripherals.iomuxc.gpio_ad_b0_00.configure(&LED_PIN_CONFIG);
-//! ```
 
 #![allow(non_camel_case_types)]
 

--- a/imxrt-hal/src/iomuxc.rs
+++ b/imxrt-hal/src/iomuxc.rs
@@ -11,7 +11,7 @@
 //! peripheral-compatible pins. Each peripheral-specific module, like `spi` and `uart`, defines
 //! a `Pin` trait. The list of trait implementors describe which pad and alternative is needed
 //! to support that peripheral. For example, an implementor of the `uart::Pin` trait is
-//! `GPIO_AD_B1_02<Alt2>`: 
+//! `GPIO_AD_B1_02<Alt2>`:
 //!
 //! ```text
 //! impl uart::Pin for GPIO_AD_B1_02<Alt2>

--- a/imxrt-hal/src/iomuxc.rs
+++ b/imxrt-hal/src/iomuxc.rs
@@ -1,4 +1,34 @@
 //! IOMUX Controller
+//!
+//! ## Configure pin settings
+//!
+//! This takes a given PinConfig and updates the *_PAD_MUX_PAD_*
+//! register related to a given Pin.
+//!
+//! If the PinConfig does not write to all fields, which is checked
+//! by PinConfig::is_modify() the config is applied as a
+//! modification to the current PAD_MUX_PAD register value.
+//!
+//! Otherwise the PAD_MUX_PAD register is overwritten with the new
+//! configuration.
+//!
+//! PinConfig docs supply more information on how to build a
+//! PinConfig and what typical defaults from the reference
+//! manual look like.
+//!
+//! # Example using const builder functions
+//!
+//! ```no_run
+//! use imxrt_hal::iomuxc::pin_config::*;
+//! use imxrt_hal::Peripherals;
+//!
+//! const LED_PIN_CONFIG: PinConfig = PinConfig::with_none()
+//!                      .set_pull_up(PullUp::PullUp_100KOhm)
+//!                      .set_speed(Speed::Speed2_150MHz)
+//!                      .set_drive_strength(DriveStrength::R0_DIV_6);
+//! let mut peripherals = Peripherals::take().unwrap();
+//! peripherals.iomuxc.gpio_ad_b0_00.configure(&LED_PIN_CONFIG);
+//! ```
 
 #![allow(non_camel_case_types)]
 

--- a/imxrt-hal/src/iomuxc.rs
+++ b/imxrt-hal/src/iomuxc.rs
@@ -1,4 +1,50 @@
-//! IOMUX Controller
+//! # IOMUX Controller
+//!
+//! The IOMUXC controller exposes all processor pads as unique GPIO structs.
+//! Each GPIO may be transitioned into various alternatives, or modes, that
+//! support different use-cases. All GPIOs are defined in [the `gpio` module](gpio/index.html).
+//!
+//! [The `pin_config` module](pin_config/index.html) lets users specify pin configurations, like
+//! pull-up resistors and pin speeds. See the module-level docs for more information.
+//!
+//! Finally, the peripheral-specific modules define type tags for pins, and traits that denote
+//! peripheral-compatible pins. Each peripheral-specific module, like `spi` and `uart`, defines
+//! a `Pin` trait. The list of trait implementors describe which pad and alternative is needed
+//! to support that peripheral. For example, an implementor of the `uart::Pin` trait is
+//! `GPIO_AD_B1_02<Alt2>`: 
+//!
+//! ```text
+//! impl uart::Pin for GPIO_AD_B1_02<Alt2>
+//!    type Direction = TX
+//!    type Module = _2
+//! ```
+//!
+//! The listing indicates that, in the second alternative, `GPIO_AD_B1_02` is a UART TX pin for
+//! UART2. The HAL's UART peripheral will design to that trait, accepting GPIOs that can satisfy
+//! the trait bounds:
+//!
+//! ```no_run
+//! use imxrt_hal;
+//!
+//! let mut peripherals = imxrt_hal::Peripherals::take().unwrap();
+//!
+//! let uarts = peripherals.uart.clock(
+//!     // ...
+//! #    &mut peripherals.ccm.handle,
+//! #    imxrt_hal::ccm::uart::ClockSelect::OSC,
+//! #    imxrt_hal::ccm::uart::PrescalarSelect::DIVIDE_1,
+//! );
+//!
+//! // Use the UART2-compatible pins to create a UART peripheral
+//! let mut uart = uarts
+//!     .uart2
+//!     .init(
+//!         peripherals.iomuxc.gpio_ad_b1_02.alt2(),
+//!         peripherals.iomuxc.gpio_ad_b1_03.alt2(),
+//!         115_200,
+//!     )
+//!     .unwrap();
+//! ```
 
 #![allow(non_camel_case_types)]
 

--- a/imxrt-hal/src/iomuxc/macros.rs
+++ b/imxrt-hal/src/iomuxc/macros.rs
@@ -229,7 +229,7 @@ macro_rules! pad {
 
             /// Configure a pin
             ///
-            /// See the [module-level docs](../index.html#configure-pin-settings) for more information.
+            /// See the [`PinConfig` docs](../pin_config/index.html#configure-pin-settings) for more information.
             pub fn configure(&mut self, cfg: &$crate::iomuxc::pin_config::PinConfig) {
                 // Safety: iomux registers are per pin and effectively owned by
                 // the pin allowing safe access so long as direct register

--- a/imxrt-hal/src/iomuxc/macros.rs
+++ b/imxrt-hal/src/iomuxc/macros.rs
@@ -227,35 +227,9 @@ macro_rules! pad {
                 unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, SION: $crate::ral::iomuxc::$mux_mod::SION::RW::DISABLED) };
             }
 
-            /// Configure pin settings
+            /// Configure a pin
             ///
-            /// This takes a given PinConfig and updates the *_PAD_MUX_PAD_*
-            /// register related to a given Pin.
-            ///
-            /// If the PinConfig does not write to all fields, which is checked
-            /// by PinConfig::is_modify() the config is applied as a
-            /// modification to the current PAD_MUX_PAD register value.
-            ///
-            /// Otherwise the PAD_MUX_PAD register is overwritten with the new
-            /// configuration.
-            ///
-            /// PinConfig docs supply more information on how to build a
-            /// PinConfig and what typical defaults from the reference
-            /// manual look like.
-            ///
-            /// # Example using const builder functions
-            ///
-            /// ```no_run
-            /// use imxrt_hal::iomuxc::pin_config::*;
-            /// use imxrt_hal::Peripherals;
-            ///
-            /// const LED_PIN_CONFIG: PinConfig = PinConfig::with_none()
-            ///                      .set_pull_up(PullUp::PullUp_100KOhm)
-            ///                      .set_speed(Speed::Speed2_150MHz)
-            ///                      .set_drive_strength(DriveStrength::R0_DIV_6);
-            /// let mut peripherals = Peripherals::take().unwrap();
-            /// peripherals.iomuxc.gpio_ad_b0_00.configure(&LED_PIN_CONFIG);
-            /// ```
+            /// See the [module-level docs](../index.html#configure-pin-settings) for more information.
             pub fn configure(&mut self, cfg: &$crate::iomuxc::pin_config::PinConfig) {
                 // Safety: iomux registers are per pin and effectively owned by
                 // the pin allowing safe access so long as direct register

--- a/imxrt-hal/src/iomuxc/macros.rs
+++ b/imxrt-hal/src/iomuxc/macros.rs
@@ -2,7 +2,14 @@ macro_rules! alt0 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt0 setting
         pub fn alt0(self) -> $Pad<$crate::iomuxc::Alt0> {
-            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT0) };
+            unsafe {
+                ::imxrt_ral::modify_reg!(
+                    $crate::ral::iomuxc,
+                    $crate::ral::iomuxc::IOMUXC,
+                    $mux_mod,
+                    MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT0
+                )
+            };
             $Pad {
                 _alt: core::marker::PhantomData,
             }
@@ -14,7 +21,14 @@ macro_rules! alt1 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt1 setting
         pub fn alt1(self) -> $Pad<$crate::iomuxc::Alt1> {
-            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT1) };
+            unsafe {
+                ::imxrt_ral::modify_reg!(
+                    $crate::ral::iomuxc,
+                    $crate::ral::iomuxc::IOMUXC,
+                    $mux_mod,
+                    MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT1
+                )
+            };
             $Pad {
                 _alt: core::marker::PhantomData,
             }
@@ -26,7 +40,14 @@ macro_rules! alt2 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt2 setting
         pub fn alt2(self) -> $Pad<$crate::iomuxc::Alt2> {
-            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT2) };
+            unsafe {
+                ::imxrt_ral::modify_reg!(
+                    $crate::ral::iomuxc,
+                    $crate::ral::iomuxc::IOMUXC,
+                    $mux_mod,
+                    MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT2
+                )
+            };
             $Pad {
                 _alt: core::marker::PhantomData,
             }
@@ -38,7 +59,14 @@ macro_rules! alt3 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt3 setting
         pub fn alt3(self) -> $Pad<$crate::iomuxc::Alt3> {
-            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT3) };
+            unsafe {
+                ::imxrt_ral::modify_reg!(
+                    $crate::ral::iomuxc,
+                    $crate::ral::iomuxc::IOMUXC,
+                    $mux_mod,
+                    MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT3
+                )
+            };
             $Pad {
                 _alt: core::marker::PhantomData,
             }
@@ -50,7 +78,14 @@ macro_rules! alt4 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt4 setting
         pub fn alt4(self) -> $Pad<$crate::iomuxc::Alt4> {
-            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT4) };
+            unsafe {
+                ::imxrt_ral::modify_reg!(
+                    $crate::ral::iomuxc,
+                    $crate::ral::iomuxc::IOMUXC,
+                    $mux_mod,
+                    MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT4
+                )
+            };
             $Pad {
                 _alt: core::marker::PhantomData,
             }
@@ -62,7 +97,14 @@ macro_rules! alt5 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt5 setting
         pub fn alt5(self) -> $Pad<$crate::iomuxc::Alt5> {
-            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT5) };
+            unsafe {
+                ::imxrt_ral::modify_reg!(
+                    $crate::ral::iomuxc,
+                    $crate::ral::iomuxc::IOMUXC,
+                    $mux_mod,
+                    MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT5
+                )
+            };
             $Pad {
                 _alt: core::marker::PhantomData,
             }
@@ -74,7 +116,14 @@ macro_rules! alt6 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt6 setting
         pub fn alt6(self) -> $Pad<$crate::iomuxc::Alt6> {
-            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT6) };
+            unsafe {
+                ::imxrt_ral::modify_reg!(
+                    $crate::ral::iomuxc,
+                    $crate::ral::iomuxc::IOMUXC,
+                    $mux_mod,
+                    MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT6
+                )
+            };
             $Pad {
                 _alt: core::marker::PhantomData,
             }
@@ -86,7 +135,14 @@ macro_rules! alt7 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt7 setting
         pub fn alt7(self) -> $Pad<$crate::iomuxc::Alt7> {
-            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT7) };
+            unsafe {
+                ::imxrt_ral::modify_reg!(
+                    $crate::ral::iomuxc,
+                    $crate::ral::iomuxc::IOMUXC,
+                    $mux_mod,
+                    MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT7
+                )
+            };
             $Pad {
                 _alt: core::marker::PhantomData,
             }
@@ -98,7 +154,14 @@ macro_rules! alt8 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt8 setting
         pub fn alt8(self) -> $Pad<$crate::iomuxc::Alt8> {
-            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT8) };
+            unsafe {
+                ::imxrt_ral::modify_reg!(
+                    $crate::ral::iomuxc,
+                    $crate::ral::iomuxc::IOMUXC,
+                    $mux_mod,
+                    MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT8
+                )
+            };
             $Pad {
                 _alt: core::marker::PhantomData,
             }
@@ -110,7 +173,14 @@ macro_rules! alt9 {
     ($Pad:ident, $mux_mod:ident) => {
         /// Converts the pad into its Alt9 setting
         pub fn alt9(self) -> $Pad<$crate::iomuxc::Alt9> {
-            unsafe { ::imxrt_ral::modify_reg!($crate::ral::iomuxc, $crate::ral::iomuxc::IOMUXC, $mux_mod, MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT9) };
+            unsafe {
+                ::imxrt_ral::modify_reg!(
+                    $crate::ral::iomuxc,
+                    $crate::ral::iomuxc::IOMUXC,
+                    $mux_mod,
+                    MUX_MODE: $crate::ral::iomuxc::$mux_mod::MUX_MODE::RW::ALT9
+                )
+            };
             $Pad {
                 _alt: core::marker::PhantomData,
             }
@@ -175,16 +245,16 @@ macro_rules! pad {
             ///
             /// # Example using const builder functions
             ///
-            /// ```ignore
+            /// ```no_run
             /// use imxrt_hal::iomuxc::pin_config::*;
             /// use imxrt_hal::Peripherals;
             ///
-            /// const led_pin_cfg = PinConfig::with_none()
-            ///                      .set_pull_keeper_enable(PullKeeperEnable::Enabled)
+            /// const LED_PIN_CONFIG: PinConfig = PinConfig::with_none()
+            ///                      .set_pull_up(PullUp::PullUp_100KOhm)
             ///                      .set_speed(Speed::Speed2_150MHz)
             ///                      .set_drive_strength(DriveStrength::R0_DIV_6);
             /// let mut peripherals = Peripherals::take().unwrap();
-            /// peripherals.iomuxc.gpio_ad_b0_00.configure(&led_pin_cfg);
+            /// peripherals.iomuxc.gpio_ad_b0_00.configure(&LED_PIN_CONFIG);
             /// ```
             pub fn configure(&mut self, cfg: &$crate::iomuxc::pin_config::PinConfig) {
                 // Safety: iomux registers are per pin and effectively owned by

--- a/imxrt-hal/src/iomuxc/pin_config.rs
+++ b/imxrt-hal/src/iomuxc/pin_config.rs
@@ -1,6 +1,35 @@
-/// Pin configuration provides types, macros, and methods for
-/// setting a pin configuration such as pull resistors, speed, and
-/// open drain options.
+//! # Pin configuration
+//!
+//! All GPIOs take a given `PinConfig` that specifies features like
+//!
+//! - pull up/down resistor connectivity and resistance
+//! - pin speed
+//! - pin drive strength
+//!
+//! If the PinConfig does not write to all fields, which is checked
+//! by PinConfig::is_modify() the config is applied as a
+//! modification to the current PAD_MUX_PAD register value.
+//!
+//! Otherwise the PAD_MUX_PAD register is overwritten with the new
+//! configuration.
+//!
+//! PinConfig docs supply more information on how to build a
+//! PinConfig and what typical defaults from the reference
+//! manual look like.
+//!
+//! # Example using const builder functions
+//!
+//! ```no_run
+//! use imxrt_hal::iomuxc::pin_config::*;
+//! use imxrt_hal::Peripherals;
+//!
+//! const LED_PIN_CONFIG: PinConfig = PinConfig::with_none()
+//!                      .set_pull_up(PullUp::PullUp_100KOhm)
+//!                      .set_speed(Speed::Speed2_150MHz)
+//!                      .set_drive_strength(DriveStrength::R0_DIV_6);
+//! let mut peripherals = Peripherals::take().unwrap();
+//! peripherals.iomuxc.gpio_ad_b0_00.configure(&LED_PIN_CONFIG);
+//! ```
 
 /// localized alias for field specific mods below
 mod pad {

--- a/imxrt-hal/src/pit.rs
+++ b/imxrt-hal/src/pit.rs
@@ -1,4 +1,28 @@
 //! Periodic Interrupt Timer (PIT)
+//!
+//! # Example
+//!
+//! ```no_run
+//! use imxrt_hal;
+//! use embedded_hal::timer::CountDown;
+//!
+//! let mut peripherals = imxrt_hal::Peripherals::take().unwrap();
+//!
+//! let (_, ipg_hz) = peripherals.ccm.pll1.set_arm_clock(
+//!     imxrt_hal::ccm::PLL1::ARM_HZ,
+//!     &mut peripherals.ccm.handle,
+//!     &mut peripherals.dcdc,
+//! );
+//!
+//! let mut cfg = peripherals.ccm.perclk.configure(
+//!     &mut peripherals.ccm.handle,
+//!     imxrt_hal::ccm::perclk::PODF::DIVIDE_3,
+//!     imxrt_hal::ccm::perclk::CLKSEL::IPG(ipg_hz),
+//! );
+//!
+//! let (_, _, _, mut timer) = peripherals.pit.clock(&mut cfg);
+//! timer.start(core::time::Duration::from_micros(200));
+//! ```
 
 use crate::ccm::{perclk, ticks, Divider, Frequency, TicksError};
 use crate::ral;

--- a/imxrt-hal/src/pwm.rs
+++ b/imxrt-hal/src/pwm.rs
@@ -12,6 +12,45 @@
 //!   in a `Handle`, to acquire a `Controller`.
 //! - `Controller` implements `embedded_hal::Pwm`. It lets you set PWM duty cycles.
 //!   Once you're done setting duty cycles, drop the `Controller`.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use imxrt_hal;
+//! use imxrt_hal::pwm::Channel;
+//! use embedded_hal::Pwm;
+//!
+//! let mut p = imxrt_hal::Peripherals::take().unwrap();
+//!
+//! let (_, ipg_hz) =
+//!     p.ccm
+//!         .pll1
+//!         .set_arm_clock(imxrt_hal::ccm::PLL1::ARM_HZ, &mut p.ccm.handle, &mut p.dcdc);
+//!
+//! let mut pwm2 = p.pwm2.clock(&mut p.ccm.handle);
+//!
+//! let mut sm2 = pwm2
+//!     .sm2
+//!     .outputs(
+//!         &mut pwm2.handle,
+//!         p.iomuxc.gpio_b0_10.alt2(),
+//!         p.iomuxc.gpio_b0_11.alt2(),
+//!         imxrt_hal::pwm::Timing {
+//!             clock_select: imxrt_hal::ccm::pwm::ClockSelect::IPG(ipg_hz),
+//!             prescalar: imxrt_hal::ccm::pwm::Prescalar::PRSC_5,
+//!             switching_period: core::time::Duration::from_micros(1000),
+//!         },
+//!     )
+//!     .unwrap();
+//!
+//! let (duty1, duty2) = (core::u16::MAX / 4, core::u16::MAX / 2);
+//! let mut ctrl = sm2.control(&mut pwm2.handle);
+//!
+//! ctrl.enable(Channel::A);
+//! ctrl.enable(Channel::B);
+//! ctrl.set_duty(Channel::A, duty1);
+//! ctrl.set_duty(Channel::B, duty2);
+//! ```
 
 use crate::ccm;
 use crate::iomuxc::pwm::Pin;

--- a/imxrt-hal/src/spi.rs
+++ b/imxrt-hal/src/spi.rs
@@ -12,6 +12,34 @@
 //! `N` is the CS number, to enable the peripheral-controlled CS. Your hardware must be wired to
 //! accomodate this selection. If you do not want to use the peripheral-controlled CS, you may
 //! select your own GPIO.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use imxrt_hal;
+//! use embedded_hal::blocking::spi::Transfer;
+//!
+//! let mut peripherals = imxrt_hal::Peripherals::take().unwrap();
+//!
+//! let (_, _, _, spi4_builder) = peripherals.spi.clock(
+//!     &mut peripherals.ccm.handle,
+//!     imxrt_hal::ccm::spi::ClockSelect::Pll2,
+//!     imxrt_hal::ccm::spi::PrescalarSelect::LPSPI_PODF_5,
+//! );
+//!
+//! let mut spi4 = spi4_builder.build(
+//!     peripherals.iomuxc.gpio_b0_02.alt3(),
+//!     peripherals.iomuxc.gpio_b0_01.alt3(),
+//!     peripherals.iomuxc.gpio_b0_03.alt3(),
+//! );
+//!
+//! spi4.enable_chip_select_0(peripherals.iomuxc.gpio_b0_00.alt3());
+//!
+//! spi4.set_clock_speed(imxrt_hal::spi::ClockSpeed(1_000_000)).unwrap();
+//!
+//! let mut buffer: [u8; 3] = [1, 2, 3];
+//! spi4.transfer(&mut buffer).unwrap();
+//! ```
 
 pub use crate::iomuxc::spi::module;
 

--- a/imxrt-hal/src/uart.rs
+++ b/imxrt-hal/src/uart.rs
@@ -3,6 +3,39 @@
 //! The UART module provides a serial peripheral that implements
 //! the `embedded_hal::serial` traits. The peripheral is sufficient
 //! for implementing basic serial communications.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use imxrt_hal;
+//! use embedded_hal::serial::{Read, Write};
+//!
+//! let mut peripherals = imxrt_hal::Peripherals::take().unwrap();
+//!
+//! let uarts = peripherals.uart.clock(
+//!     &mut peripherals.ccm.handle,
+//!     imxrt_hal::ccm::uart::ClockSelect::OSC,
+//!     imxrt_hal::ccm::uart::PrescalarSelect::DIVIDE_1,
+//! );
+//!
+//! let mut uart = uarts
+//!     .uart2
+//!     .init(
+//!         peripherals.iomuxc.gpio_ad_b1_02.alt2(),
+//!         peripherals.iomuxc.gpio_ad_b1_03.alt2(),
+//!         115_200,
+//!     )
+//!     .unwrap();
+//!
+//! uart.set_tx_fifo(core::num::NonZeroU8::new(3));
+//! uart.set_rx_fifo(true);
+//! uart.set_parity(Some(imxrt_hal::uart::Parity::Even));
+//! uart.set_rx_inversion(true);
+//! uart.set_tx_inversion(false);
+//!
+//! uart.write(0xDE).unwrap();
+//! let byte = uart.read().unwrap();
+//! ```
 
 use crate::ccm;
 pub use crate::iomuxc::uart::{self, module};


### PR DESCRIPTION
Keeping on my documentation kick, the PR adds module-level examples for almost all of the peripherals. `cargo test` will make sure that all of these examples compile. I derived them from the Teensy 4 examples.

I'm also including a fix to the HAL's `Cargo.toml`. The HAL's documentation [fails to build on docs.rs](https://docs.rs/crate/imxrt-hal/0.2.1/builds). We specify a feature-flag to use when generating the docs, which should fix the doc build. I tested it locally, but we'll know if it works the next time we release the HAL.