### PR TITLE
Support split UART peripherals

### DIFF
--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `uart::ReadError` implements `Clone`, `Debug`, `PartialEq`, and `Eq`
 - `UART` peripherals may be `split()` into `Tx` and `Rx` halves
+- `UART` peripherals implement the blocking `embedded_hal` traits
 - General purpose timers (GPT)
 - Introducing the DMA module
   - Peripheral-to-memory transfers, supporting both SPI and UART

--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `uart::ReadError` implements `Clone`, `Debug`, `PartialEq`, and `Eq`
+- `UART` peripherals may be `split()` into `Tx` and `Rx` halves
 - General purpose timers (GPT)
 - Introducing the DMA module
   - Peripheral-to-memory transfers, supporting both SPI and UART

--- a/imxrt-hal/src/dma/peripheral.rs
+++ b/imxrt-hal/src/dma/peripheral.rs
@@ -94,6 +94,8 @@ mod private {
 
     use crate::uart;
     impl<M> Sealed for uart::UART<M> where M: uart::module::Module {}
+    impl<M> Sealed for uart::Rx<M> where M: uart::module::Module {}
+    impl<M> Sealed for uart::Tx<M> where M: uart::module::Module {}
 
     use crate::spi;
     impl<M> Sealed for spi::SPI<M> where M: spi::module::Module {}

--- a/imxrt-hal/src/iomuxc/uart.rs
+++ b/imxrt-hal/src/iomuxc/uart.rs
@@ -3,6 +3,8 @@
 use crate::ral;
 
 pub mod module {
+    use super::ral;
+
     pub trait Module {
         const IDX: usize;
         /// UART TX DMA Request signal
@@ -13,54 +15,93 @@ pub mod module {
         ///
         /// See table 4-3 of the iMXRT1060 Reference Manual (Rev 2)
         const RX_DMA_REQUEST: u32;
+
+        /// Steal the UART instance
+        ///
+        /// # Safety
+        ///
+        /// The instance may be used elsewhere
+        unsafe fn steal() -> ral::lpuart::Instance;
     }
     pub struct _1;
     impl Module for _1 {
         const IDX: usize = 1;
         const TX_DMA_REQUEST: u32 = 2;
         const RX_DMA_REQUEST: u32 = 3;
+
+        unsafe fn steal() -> ral::lpuart::Instance {
+            ral::lpuart::LPUART1::steal()
+        }
     }
     pub struct _2;
     impl Module for _2 {
         const IDX: usize = 2;
         const TX_DMA_REQUEST: u32 = 66;
         const RX_DMA_REQUEST: u32 = 67;
+
+        unsafe fn steal() -> ral::lpuart::Instance {
+            ral::lpuart::LPUART2::steal()
+        }
     }
     pub struct _3;
     impl Module for _3 {
         const IDX: usize = 3;
         const TX_DMA_REQUEST: u32 = 4;
         const RX_DMA_REQUEST: u32 = 5;
+
+        unsafe fn steal() -> ral::lpuart::Instance {
+            ral::lpuart::LPUART3::steal()
+        }
     }
     pub struct _4;
     impl Module for _4 {
         const IDX: usize = 4;
         const TX_DMA_REQUEST: u32 = 68;
         const RX_DMA_REQUEST: u32 = 69;
+
+        unsafe fn steal() -> ral::lpuart::Instance {
+            ral::lpuart::LPUART4::steal()
+        }
     }
     pub struct _5;
     impl Module for _5 {
         const IDX: usize = 5;
         const TX_DMA_REQUEST: u32 = 6;
         const RX_DMA_REQUEST: u32 = 7;
+
+        unsafe fn steal() -> ral::lpuart::Instance {
+            ral::lpuart::LPUART5::steal()
+        }
     }
     pub struct _6;
     impl Module for _6 {
         const IDX: usize = 6;
         const TX_DMA_REQUEST: u32 = 70;
         const RX_DMA_REQUEST: u32 = 71;
+
+        unsafe fn steal() -> ral::lpuart::Instance {
+            ral::lpuart::LPUART6::steal()
+        }
     }
     pub struct _7;
     impl Module for _7 {
         const IDX: usize = 7;
         const TX_DMA_REQUEST: u32 = 8;
         const RX_DMA_REQUEST: u32 = 9;
+
+        unsafe fn steal() -> ral::lpuart::Instance {
+            ral::lpuart::LPUART7::steal()
+        }
     }
     pub struct _8;
     impl Module for _8 {
         const IDX: usize = 8;
         const TX_DMA_REQUEST: u32 = 72;
         const RX_DMA_REQUEST: u32 = 73;
+
+        unsafe fn steal() -> ral::lpuart::Instance {
+            ral::lpuart::LPUART8::steal()
+        }
     }
 }
 

--- a/imxrt-hal/src/uart.rs
+++ b/imxrt-hal/src/uart.rs
@@ -675,3 +675,8 @@ where
         self.0.disable_destination()
     }
 }
+
+use embedded_hal::blocking::serial::write::Default as BlockingWrite;
+
+impl<M> BlockingWrite<u8> for UART<M> where M: module::Module {}
+impl<M> BlockingWrite<u8> for Tx<M> where M: module::Module {}

--- a/imxrt-hal/src/uart.rs
+++ b/imxrt-hal/src/uart.rs
@@ -622,6 +622,23 @@ where
     }
 }
 
+impl<M> dma::peripheral::Source<u8> for Rx<M>
+where
+    M: module::Module,
+{
+    type Error = void::Void;
+    const SOURCE_REQUEST_SIGNAL: u32 = M::RX_DMA_REQUEST;
+    fn source(&self) -> *const u8 {
+        self.0.source()
+    }
+    fn enable_source(&mut self) -> Result<(), Self::Error> {
+        self.0.enable_source()
+    }
+    fn disable_source(&mut self) {
+        self.0.disable_source()
+    }
+}
+
 impl<M> dma::peripheral::Destination<u8> for UART<M>
 where
     M: module::Module,
@@ -639,5 +656,22 @@ where
         while ral::read_reg!(ral::lpuart, self.reg, BAUD, TDMAE == 1) {
             ral::modify_reg!(ral::lpuart, self.reg, BAUD, TDMAE: 0);
         }
+    }
+}
+
+impl<M> dma::peripheral::Destination<u8> for Tx<M>
+where
+    M: module::Module,
+{
+    type Error = void::Void;
+    const DESTINATION_REQUEST_SIGNAL: u32 = M::TX_DMA_REQUEST;
+    fn destination(&self) -> *const u8 {
+        self.0.destination()
+    }
+    fn enable_destination(&mut self) -> Result<(), Self::Error> {
+        self.0.enable_destination()
+    }
+    fn disable_destination(&mut self) {
+        self.0.disable_destination()
     }
 }


### PR DESCRIPTION
I'm thinking about adding a new, UART-based logging back-end for the Teensy. Logging might only need the transfer half of a UART peripheral. This PR proposes split-able UART peripherals.

Users can `split()` a peripheral into transfer and receive halves. The transfer half only supports writes; the receive half, only reads. Users can `join()` the halves if they need to re-configure the
peripheral. The two halves implement the DMA's `Source` and `Destination` traits, so they may serve as uni-directional DMA sources and destinations.

Tested in the Teensy 4 repo, at [aca5424](https://github.com/mciantyre/teensy4-rs/commit/aca5424ea07cfe1421362cc7dd6a6912b5dad6a2).