### PR TITLE
Send RAL instances

### DIFF
--- a/imxrt-ral/imxrtral.py
+++ b/imxrt-ral/imxrtral.py
@@ -809,7 +809,7 @@ class PeripheralPrototype(Node):
                 unsafe { &*(self.addr as *const _) }
             }
         }
-        #[cfg(feature="rtfm")]
+
         unsafe impl Send for Instance {}
 
         """


### PR DESCRIPTION
The PR proposes that all RAL instances are `Send`. `Send`-able `Instance`s are [feature-gated behind `"rtfm"`](https://docs.rs/imxrt-ral/0.2.1/src/imxrt_ral/imxrt106/peripherals/lpi2c.rs.html#2704), but it seems like a useful feature for non-RTFM users.

By enabling `Send` for RAL instances, most HAL peripherals will also become `Send`. We can then wrap HAL peripherals in `Sync`-able [`cortex_m::interrupt::Mutex`es](https://docs.rs/cortex-m/0.6.2/cortex_m/interrupt/struct.Mutex.html), or use them wherever else `Send` is necessary.

`Send`-able RAL instances would match what `svd2rust` outputs ([sample](https://docs.rs/stm32f0/0.11.0/src/stm32f0/stm32f0x8/mod.rs.html#417) of an `svd2rust` output). Both RAL and `svd2rust` instance types serve the same goal: dereference to a register block. It seems to follow that they may both be `Send`.

If accepted, we must **re-generate of the RAL**. Follow the guidance in [CONTRIBUTING](https://github.com/imxrt-rs/imxrt-rs/blob/3c54725f233cd9d972593b058e8784e1d6f1c38f/CONTRIBUTING.md) to re-generate the RAL. Alternatively, we may manually implement `Send` on peripherals in the HAL.