### PR TITLE
Mark DMA channels as sendable

### DIFF
--- a/imxrt-hal/src/dma.rs
+++ b/imxrt-hal/src/dma.rs
@@ -591,3 +591,8 @@ impl<E: Element> Transfer<E> {
         }
     }
 }
+
+// It's OK to send a channel across an execution context.
+// They can't be cloned or copied, so there's no chance of
+// them being (mutably) shared.
+unsafe impl Send for Channel {}


### PR DESCRIPTION
I intended to mark these as `Send` in #49, but I missed it! This PR marks DMA channels as `Send` so they may be used wherever `Send` things are needed, like `Mutex`es.

Will be part of #59.