### PR TITLE
Prepare 0.3.0 release of RAL and HAL

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,17 +4,17 @@ From a clean repository, at the root:
 
 1. Update the `imxrt-ral` crate version in `imxrt-ral/imxrtral.py`.
 2. Build the RAL: `make -C imxrt-ral`
-3. Sanity check the RAL: 
+3. In `imxrt-hal/Cargo.toml`, update both
+    - the version of the HAL
+    - the HAL's dependency of the RAL
+4. Sanity check the RAL: 
 
 ```
 cd imxrt-ral && cargo build --features imxrt1062 && cd ..
 ```
 
-4. Publish the RAL: `cargo publish --manifest-path imxrt-ral/Cargo.toml`
-5. In `imxrt-hal/Cargo.toml`, update both
-    - the version of the HAL
-    - the HAL's dependency of the RAL
-6. Sanity check the HAL. Note that this will reference the RAL published to crates.io in step 4.
+5. Publish the RAL: `cargo publish --manifest-path imxrt-ral/Cargo.toml`
+6. Sanity check the HAL.
 
 ```
 cd imxrt-hal && cargo build --features imxrt1062 && cd ..

--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.3.0] - 2020-06-18
+
 ### Added
 
 - `uart::ReadError` implements `Clone`, `Debug`, `PartialEq`, and `Eq`
@@ -25,4 +27,5 @@
 
 Prior releases were not tracked with a changelog entry.
 
-[Unreleased]: https://github.com/imxrt-rs/imxrt-rs/compare/0.2.1...HEAD
+[Unreleased]: https://github.com/imxrt-rs/imxrt-rs/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/imxrt-rs/imxrt-rs/compare/0.2.1...0.3.0

--- a/imxrt-hal/Cargo.toml
+++ b/imxrt-hal/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 version = "0.3.0"
 
-
 [dependencies]
 as-slice = "0.1.3"
 cortex-m = { version = "0.6" }

--- a/imxrt-hal/Cargo.toml
+++ b/imxrt-hal/Cargo.toml
@@ -3,19 +3,18 @@ name = "imxrt-hal"
 authors = ["Tom Burdick <tom.burdick@electromatic.us>", "Ian McIntyre <ianpmcintyre@gmail.com>"]
 description = "Hardware abstraction layer for all NXP i.MX RT microcontrollers"
 repository = "https://github.com/imxrt-rs/imxrt-rs"
-documentation = "https://docs.rs/imxrt"
 readme = "README.md"
 keywords = ["imxrt", "nxp", "embedded", "no_std"]
 categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2018"
-version = "0.2.1"
+version = "0.3.0"
 
 
 [dependencies]
 as-slice = "0.1.3"
 cortex-m = { version = "0.6" }
-imxrt-ral = { version = "0.2.1", path = "../imxrt-ral" }
+imxrt-ral = { version = "0.3.0", path = "../imxrt-ral" }
 bitflags = "1.2.1"
 embedded-hal = "0.2.3"
 nb = "0.1.2"

--- a/imxrt-ral/CHANGELOG.md
+++ b/imxrt-ral/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [0.3.0] 2020-06-18
+
+* Only emit link section for `__INTERRUPTS` when compiling for ARM targets
 * Fix RAL's documentation to refer to i.MX RT registers
 
 ## [0.2.1] 2020-04-10
@@ -17,7 +20,8 @@
 
 Initial build and release of imxrt family of peripheral access crates
 
-[Unreleased]: https://github.com/imxrt-rs/imxrt-rs/compare/0.2.1...HEAD
+[Unreleased]: https://github.com/imxrt-rs/imxrt-rs/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/imxrt-rs/imxrt-rs/compare/0.2.1...0.3.0
 [0.2.1]: https://github.com/imxrt-rs/imxrt-rs/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/imxrt-rs/imxrt-rs/compare/0.1.0...0.2.1
 [0.1.0]: https://github.com/imxrt-rs/imxrt-rs/releases/tag/0.1.0

--- a/imxrt-ral/imxrtral.py
+++ b/imxrt-ral/imxrtral.py
@@ -56,7 +56,6 @@ name = "imxrt-ral"
 authors = ["Tom Burdick <tom.burdick@electromatic.us>", "Ian McIntyre <ianpmcintyre@gmail.com>"]
 description = "Register access layer for all NXP i.MX RT microcontrollers"
 repository = "https://github.com/imxrt-rs/imxrt-rs"
-documentation = "https://docs.rs/imxrt"
 readme = "README.md"
 keywords = ["imxrt", "nxp", "embedded", "no_std"]
 categories = ["embedded", "no-std"]
@@ -64,7 +63,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 # Change version in imxrtral.py, not in Cargo.toml!
-version = "0.2.1"
+version = "0.3.0"
 
 [package.metadata.docs.rs]
 features = ["doc"]


### PR DESCRIPTION
All builds and publish dry-runs look OK at this point. I updated the release steps to better order the process.

I removed the `documentation` keys from both `Cargo.toml` files. Neither key pointed to a valid page on docs.rs, and it sounds like crates.io will [automatically provide the link](https://doc.rust-lang.org/cargo/reference/manifest.html#the-documentation-field) if we don't specify it.

Closes #59.