### PR TITLE
Conditionally emit __INTERRUPT link section

### DIFF
--- a/imxrt-ral/imxrtral.py
+++ b/imxrt-ral/imxrtral.py
@@ -1215,7 +1215,7 @@ class Device(Node):
 
                 #[cfg(feature="rt")]
                 #[doc(hidden)]
-                #[link_section=".vector_table.interrupts"]
+                #[cfg_attr(target_arch = "arm", link_section = ".vector_table.interrupts")]
                 #[no_mangle]
                 pub static __INTERRUPTS: [Vector; {nvectors}] = [
                 {vectors}


### PR DESCRIPTION
Trying to squeeze in one more change before the release (#59)! If accepted, this change requires a re-build of the RAL.

I came upon this when I was writing automated unit tests for the [imxrt-uart-log](https://github.com/imxrt-rs/imxrt-uart-log) logging crate. I want to run 'cargo test' on my mac to run unit and doc tests. But, I hit an error:

```
  LLVM ERROR: Global variable '__INTERRUPTS' has an invalid section
  specifier '.vector_table.interrupts': mach-o section specifier
  requires a segment whose length is between 1 and 16 characters.
```

Rather than always emitting the link section for `__INTERRUPTS`, we conditionally emit the link section when building for ARM targets. This lets me run unit tests on my host, while still including the link section for the targets that need it.

I've been testing with this change in a separate branch during imxrt-uart-log development. I'm also implementing similar solutions in the `teensy4-rs` crates.

#### Why doesn't this happen when you run `cargo test` in this repo?

The imxrt-uart-log crate relies on the `"rt"` feature-flag when building developer dependencies, like tests. The issue *is* reproducible when I run `cargo test --features imxrt1062 --features rt` in this repo.