### PR TITLE
steal() peripherals; update changelog

### DIFF
--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** The HAL's `"rtfm"` feature is changed to `"rtic"`, reflecting the framework's
+  new name. Users who are relying on the `"rtfm"` feature should now use the `"rtic"` feature.
+
 ## [0.3.0] - 2020-06-18
 
 ### Added

--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- `steal()` the top-level `Peripherals` object. The `steal()` method lets users use the `imxrt_hal`
+  as an RTIC device.
+
 ### Changed
 
 - **BREAKING** The HAL's `"rtfm"` feature is changed to `"rtic"`, reflecting the framework's

--- a/imxrt-hal/src/lib.rs
+++ b/imxrt-hal/src/lib.rs
@@ -57,6 +57,55 @@ pub struct Peripherals {
 }
 
 impl Peripherals {
+    /// Steal all of the HAL's peripherals
+    ///
+    /// # Safety
+    ///
+    /// The peripherals may be mutably aliased elsewhere in the code. Consider using
+    /// [`take()`](struct.Peripherals.html#method.take) to safely acquire the HAL's
+    /// peripherals.
+    pub unsafe fn steal() -> Self {
+        Peripherals {
+            iomuxc: iomuxc::IOMUXC::new(ral::iomuxc::IOMUXC::steal()),
+            ccm: ccm::CCM::new(ral::ccm::CCM::steal(), ral::ccm_analog::CCM_ANALOG::steal()),
+            pit: pit::UnclockedPIT::new(ral::pit::PIT::steal()),
+            dcdc: dcdc::DCDC(ral::dcdc::DCDC::steal()),
+            pwm1: pwm::Unclocked::new(ral::pwm::PWM1::steal()),
+            pwm2: pwm::Unclocked::new(ral::pwm::PWM2::steal()),
+            pwm3: pwm::Unclocked::new(ral::pwm::PWM3::steal()),
+            pwm4: pwm::Unclocked::new(ral::pwm::PWM4::steal()),
+            i2c: i2c::Unclocked {
+                i2c1: ral::lpi2c::LPI2C1::steal(),
+                i2c2: ral::lpi2c::LPI2C2::steal(),
+                i2c3: ral::lpi2c::LPI2C3::steal(),
+                i2c4: ral::lpi2c::LPI2C4::steal(),
+            },
+            uart: uart::Unclocked {
+                uart1: ral::lpuart::LPUART1::steal(),
+                uart2: ral::lpuart::LPUART2::steal(),
+                uart3: ral::lpuart::LPUART3::steal(),
+                uart4: ral::lpuart::LPUART4::steal(),
+                uart5: ral::lpuart::LPUART5::steal(),
+                uart6: ral::lpuart::LPUART6::steal(),
+                uart7: ral::lpuart::LPUART7::steal(),
+                uart8: ral::lpuart::LPUART8::steal(),
+            },
+            spi: spi::Unclocked {
+                spi1: ral::lpspi::LPSPI1::steal(),
+                spi2: ral::lpspi::LPSPI2::steal(),
+                spi3: ral::lpspi::LPSPI3::steal(),
+                spi4: ral::lpspi::LPSPI4::steal(),
+            },
+            gpt1: gpt::Unclocked::one(ral::gpt::GPT1::steal()),
+            gpt2: gpt::Unclocked::two(ral::gpt::GPT2::steal()),
+            dma: dma::Unclocked::new(ral::dma0::DMA0::steal(), ral::dmamux::DMAMUX::steal()),
+        }
+    }
+
+    /// Take the HAL's peripherals
+    ///
+    /// If the peripherals were already taken, `take()` returns `None`. Consider calling `take()`
+    /// near the start of your program.
     pub fn take() -> Option<Self> {
         let p = Peripherals {
             iomuxc: iomuxc::IOMUXC::new(ral::iomuxc::IOMUXC::take()?),

--- a/imxrt-ral/CHANGELOG.md
+++ b/imxrt-ral/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* **BREAKING** The RAL's `"rtfm"` feature is changed to `"rtic"`, reflecting the framework's
+  new name. Users who are relying on the `"rtfm"` feature should now use the `"rtic"` feature.
+
 ## [0.3.0] 2020-06-18
 
 * Only emit link section for `__INTERRUPTS` when compiling for ARM targets


### PR DESCRIPTION
The PR adds a new function, `steal()`, to `Peripherals`. `steal()` lets users unsafely acquire all of the peripheral objects. It's unsafe, because the peripherals could be used elsewhere.

`steal()` is used by the RTIC framework to acquire device peripherals. The framework then hands-off the peripherals to the user, who can configure them and wrap them as additional (late) resources.

Users can `steal()` peripherals in non-RTIC applications. Note that `steal()` always returns the "uninitialized" types, which require additional setup to be useful. In that regard, it's a round-about, unsafe approach towards #20. However, as of this writing, there's no testing to see if re-initializing works for all peripherals.