### PR TITLE
Fix StatefulOutputPin and read from data register

### DIFF
--- a/imxrt-hal/src/gpio.rs
+++ b/imxrt-hal/src/gpio.rs
@@ -124,7 +124,7 @@ macro_rules! _ios_impl {
                 fn is_set_high(&self) -> Result<bool, Self::Error> {
                     Ok(unsafe {
                         let regs = &(*GPIO::into_reg());
-                        (regs.PSR.read() & self.offset) > 0
+                        (regs.DR.read() & self.offset) > 0
                     })
                 }
 


### PR DESCRIPTION
We should read PSR when the GPIO is an input pin. When its an output
pin, and we want to know what state we're in, we should instead read
the data register.

Found by @mitchmindtree during teensy4-rs prototyping. Mitch found
that is_set_high() always returned `false`, even when we could see
that the GPIO was high. I also reproduced this in the teensy4-rs'
USB example, printing the state of the LED. Reading the DR register
resolved the issue in my testing.