### PR TITLE
DMA: remove configuration types

### DIFF
--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -6,11 +6,16 @@
 
 - `steal()` the top-level `Peripherals` object. The `steal()` method lets users use the `imxrt_hal`
   as an RTIC device.
+- DMA `Memcpy` may support interrupt handling
 
 ### Changed
 
 - **BREAKING** The HAL's `"rtfm"` feature is changed to `"rtic"`, reflecting the framework's
   new name. Users who are relying on the `"rtfm"` feature should now use the `"rtic"` feature.
+- **BREAKING** The `dma::{Config, ConfigBuilder}` types are gone. This affects the `dma::Peripheral`
+  interface. To configure interrupt on completion / half settings, use `dma::Channel::set_interrupt_on_completion()`
+  / `dma::Channel::set_interrupt_on_half()` to perform the same configurations before suppling the
+  channel to `dma::Peripheral`.
 
 ### Fixed
 


### PR DESCRIPTION
Queueing up additional, breaking HAL changes. This PR removes the `dma::{Config, ConfigBuilder}` types. Instead of providing separate values to describe interrupt on completion / half configuration, we set the configurations directly on a DMA `Channel`. The new approach lets us support interrupts when `Memcpy` operations complete. It also lets us track DMA channel configurations with the DMA channel itself, rather than having disparate types to maintain the settings.