### PR TITLE
Support a safer IOMUXC interface

### DIFF
--- a/imxrt-hal/src/gpio.rs
+++ b/imxrt-hal/src/gpio.rs
@@ -134,7 +134,7 @@ where
     ///
     /// All pads may be used as a GPIO, so this should always work.
     pub fn new(mut pin: P) -> Self {
-        unsafe { crate::iomuxc::gpio::prepare(&mut pin) };
+        crate::iomuxc::gpio::prepare(&mut pin);
         Self {
             pin,
             dir: PhantomData,

--- a/imxrt-hal/src/i2c.rs
+++ b/imxrt-hal/src/i2c.rs
@@ -105,10 +105,8 @@ where
         SCL: i2c::Pin<Module = M, Signal = i2c::SCL>,
         SDA: i2c::Pin<Module = M, Signal = i2c::SDA>,
     {
-        unsafe {
-            crate::iomuxc::i2c::prepare(&mut scl);
-            crate::iomuxc::i2c::prepare(&mut sda);
-        }
+        crate::iomuxc::i2c::prepare(&mut scl);
+        crate::iomuxc::i2c::prepare(&mut sda);
         I2C::new(self.source_clock, self.reg)
     }
 }

--- a/imxrt-hal/src/spi.rs
+++ b/imxrt-hal/src/spi.rs
@@ -143,11 +143,9 @@ where
         SDI: spi::Pin<Module = M, Signal = spi::SDI>,
         SCK: spi::Pin<Module = M, Signal = spi::SCK>,
     {
-        unsafe {
-            crate::iomuxc::spi::prepare(&mut sdo);
-            crate::iomuxc::spi::prepare(&mut sdi);
-            crate::iomuxc::spi::prepare(&mut sck);
-        }
+        crate::iomuxc::spi::prepare(&mut sdo);
+        crate::iomuxc::spi::prepare(&mut sdi);
+        crate::iomuxc::spi::prepare(&mut sck);
 
         SPI::new(self.source_clock, self.reg)
     }
@@ -275,7 +273,7 @@ where
     where
         PCS: spi::Pin<Module = M, Signal = spi::PCS0>,
     {
-        unsafe { crate::iomuxc::spi::prepare(&mut pcs) };
+        crate::iomuxc::spi::prepare(&mut pcs);
     }
 
     /// Set the SPI mode for the peripheral

--- a/imxrt-hal/src/uart.rs
+++ b/imxrt-hal/src/uart.rs
@@ -254,10 +254,8 @@ where
         TX: uart::Pin<Direction = uart::TX, Module = M>,
         RX: uart::Pin<Direction = uart::RX, Module = M>,
     {
-        unsafe {
-            crate::iomuxc::uart::prepare(&mut tx);
-            crate::iomuxc::uart::prepare(&mut rx);
-        }
+        crate::iomuxc::uart::prepare(&mut tx);
+        crate::iomuxc::uart::prepare(&mut rx);
         UART::start(self.reg, self.effective_clock, baud)
     }
 }

--- a/imxrt-iomuxc/src/i2c.rs
+++ b/imxrt-iomuxc/src/i2c.rs
@@ -33,14 +33,8 @@ pub trait Pin: super::IOMUX {
 ///
 /// If you do not call `prepare()` on your I2C pin, it might not work as a I2C
 /// pin.
-///
-/// # Safety
-///
-/// `prepare()` inherits all the unsafety that comes from the `IOMUX` supertrait.
-/// In particular, we cannot be sure that the implementation's pointers are correct.
-/// It may also write a daisy configuration that's incorrect.
-pub unsafe fn prepare<P: Pin>(pin: &mut P) {
+pub fn prepare<P: Pin>(pin: &mut P) {
     super::alternate(pin, P::ALT);
     super::set_sion(pin);
-    P::DAISY.write();
+    unsafe { P::DAISY.write() };
 }

--- a/imxrt-iomuxc/src/pwm.rs
+++ b/imxrt-iomuxc/src/pwm.rs
@@ -33,6 +33,6 @@ pub trait Pin: super::IOMUX {
 /// # Safety
 ///
 /// `prepare()` inherits all the unsafety of the `IOMUX` supertrait.
-pub unsafe fn prepare<P: Pin>(pin: &mut P) {
+pub fn prepare<P: Pin>(pin: &mut P) {
     super::alternate(pin, P::ALT);
 }

--- a/imxrt-iomuxc/src/spi.rs
+++ b/imxrt-iomuxc/src/spi.rs
@@ -45,8 +45,8 @@ pub trait Pin: super::IOMUX {
 /// # Safety
 ///
 /// `prepare()` inherits all the unsafety that comes from the `IOMUX` supertrait.
-pub unsafe fn prepare<P: Pin>(pin: &mut P) {
+pub fn prepare<P: Pin>(pin: &mut P) {
     super::alternate(pin, P::ALT);
     super::set_sion(pin);
-    P::DAISY.write();
+    unsafe { P::DAISY.write() };
 }

--- a/imxrt-iomuxc/src/uart.rs
+++ b/imxrt-iomuxc/src/uart.rs
@@ -39,10 +39,10 @@ pub trait Pin: super::IOMUX {
 /// `prepare()` inherits all the unsafety that comes from the `IOMUX` supertrait.
 /// In particular, we cannot be sure that the implementation's pointers are correct.
 /// It may also write a daisy configuration that's incorrect.
-pub unsafe fn prepare<P: Pin>(pin: &mut P) {
+pub fn prepare<P: Pin>(pin: &mut P) {
     super::alternate(pin, P::ALT);
     super::clear_sion(pin);
     if let Some(daisy) = P::DAISY {
-        daisy.write();
+        unsafe { daisy.write() };
     }
 }


### PR DESCRIPTION
When we first proposed the iomuxc crate (#73), we said that most of the API was `unsafe`. We stressed the unsafety of functions like `set_sion()`, `configure()`, and `prepare()`, since the functions acted on types that were implemented *outside* of the crate, and we couldn't attest to their correctness.

In #75, we moved to a single crate with feature-flags implementation. Now that all pads are implemented in the same crate, we can easily check correctness of the implementations. The PR marks the pin preparation and pad configuration & muxing functions as safe.

It it still unsafe to generate the pad objects. But, as long as an interface guarantees only one live instance of a pad, everything should be sound. Let me know if we see any issues, or if we should keep these `unsafe`.

(In hindsight, the `unsafe` traits are probably enough to signal unsafety, instead of also making the functions unsafe.)