### PR TITLE
Release v0.4

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,23 +2,23 @@
 
 From a clean repository, at the root:
 
-1. Update the `imxrt-ral` crate version in `imxrt-ral/imxrtral.py`.
-2. Build the RAL: `make -C imxrt-ral`
+1. Update the `imxrt-iomuxc` crate versions.
+2. Update the `imxrt-ral` crate version in `imxrt-ral/imxrtral.py`.
 3. In `imxrt-hal/Cargo.toml`, update both
     - the version of the HAL
     - the HAL's dependency of the RAL
-4. Sanity check the RAL: 
-
-```
-cd imxrt-ral && cargo build --features imxrt1062 && cd ..
-```
-
-5. Publish the RAL: `cargo publish --manifest-path imxrt-ral/Cargo.toml`
-6. Sanity check the HAL.
-
-```
-cd imxrt-hal && cargo build --features imxrt1062 && cd ..
-```
-
-7. Make a commit of the release.
-8. Publish the HAL: `cargo publish --manifest-path imxrt-hal/Cargo.toml --features imxrt1062`
+4. Generate the RAL: `make -C imxrt-ral`
+5. Commit the changes, and create a tag.
+6. Publish the IOMUXC crates:
+    ```
+    cargo publish --manifest-path imxrt-iomuxc/imxrt-iomuxc-build/Cargo.toml
+    cargo publish --manifest-path imxrt-iomuxc/Cargo.toml --all-features
+    ```
+7. Publish the RAL:
+    ```
+    cargo publish --manifest-path imxrt-ral/Cargo.toml
+    ```
+8. Publish the HAL:
+    ```
+    cargo publish --manifest-path imxrt-hal/Cargo.toml --features imxrt1062
+    ```

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -22,3 +22,17 @@ From a clean repository, at the root:
     ```
     cargo publish --manifest-path imxrt-hal/Cargo.toml --features imxrt1062
     ```
+
+## Maintaining older releases
+
+This section describes how imxrt-rs project maintainers support older releases.
+If there is a bug fix that you would like to apply to an older version of the
+RAL, HAL, or IOMUXC crates, follow the process below to create a new patch
+release.
+
+- Integrate bug fixes on the main branch.
+- If it doesn't already exist, create a maintenance branch. The maintenance branch should
+  branch from the commit tagged with the release. It should be named `maint-v[VERSION]`,
+  where `VERSION` is the major and minor release numbers.
+- Cherry-pick or backport the patches onto the maintenance branch.
+- Tag the release on the maintenance branch.

--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.4.0] 2020-08-29
+
+This release contains numerous breaking HAL changes. See the "Changed" section for more information.
+
 ### Added
 
 - `steal()` the top-level `Peripherals` object. The `steal()` method lets users use the `imxrt_hal`
@@ -151,5 +155,6 @@
 
 Prior releases were not tracked with a changelog entry.
 
-[Unreleased]: https://github.com/imxrt-rs/imxrt-rs/compare/0.3.0...HEAD
+[Unreleased]: https://github.com/imxrt-rs/imxrt-rs/compare/0.4.0...HEAD
+[0.4.0]: https://github.com/imxrt-rs/imxrt-rs/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/imxrt-rs/imxrt-rs/compare/0.2.1...0.3.0

--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [0.4.0] 2020-08-29
 
 This release contains numerous breaking HAL changes. See the "Changed" section for more information.
+The release includes 0.3.1 fixes.
 
 ### Added
 
@@ -124,6 +125,8 @@ This release contains numerous breaking HAL changes. See the "Changed" section f
   / `dma::Channel::set_interrupt_on_half()` to perform the same configurations before suppling the
   channel to `dma::Peripheral`.
 
+## [0.3.1] 2020-08-29
+
 ### Fixed
 
 - The `StatefulOutputPin` implementation was reading from the wrong GPIO register. The interface
@@ -157,4 +160,5 @@ Prior releases were not tracked with a changelog entry.
 
 [Unreleased]: https://github.com/imxrt-rs/imxrt-rs/compare/0.4.0...HEAD
 [0.4.0]: https://github.com/imxrt-rs/imxrt-rs/compare/0.3.0...0.4.0
+[0.3.1]: https://github.com/imxrt-rs/imxrt-rs/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/imxrt-rs/imxrt-rs/compare/0.2.1...0.3.0

--- a/imxrt-hal/Cargo.toml
+++ b/imxrt-hal/Cargo.toml
@@ -8,12 +8,12 @@ keywords = ["imxrt", "nxp", "embedded", "no_std"]
 categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2018"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 as-slice = "0.1.3"
 cortex-m = { version = "0.6" }
-imxrt-ral = { version = "0.3.0", path = "../imxrt-ral" }
+imxrt-ral = { version = "0.4.0", path = "../imxrt-ral" }
 bitflags = "1.2.1"
 embedded-hal = "0.2.3"
 nb = "0.1.2"

--- a/imxrt-ral/CHANGELOG.md
+++ b/imxrt-ral/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.4.0] 2020-08-29
+
 * **BREAKING** The RAL's `"rtfm"` feature is changed to `"rtic"`, reflecting the framework's
   new name. Users who are relying on the `"rtfm"` feature should now use the `"rtic"` feature.
 
@@ -23,7 +25,8 @@
 
 Initial build and release of imxrt family of peripheral access crates
 
-[Unreleased]: https://github.com/imxrt-rs/imxrt-rs/compare/0.3.0...HEAD
+[Unreleased]: https://github.com/imxrt-rs/imxrt-rs/compare/0.4.0...HEAD
+[0.4.0]: https://github.com/imxrt-rs/imxrt-rs/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/imxrt-rs/imxrt-rs/compare/0.2.1...0.3.0
 [0.2.1]: https://github.com/imxrt-rs/imxrt-rs/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/imxrt-rs/imxrt-rs/compare/0.1.0...0.2.1

--- a/imxrt-ral/Cargo.toml
+++ b/imxrt-ral/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 ]
 
 # Change version in imxrtral.py, not in Cargo.toml!
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/imxrt-ral/imxrtral.py
+++ b/imxrt-ral/imxrtral.py
@@ -68,7 +68,7 @@ include = [
 ]
 
 # Change version in imxrtral.py, not in Cargo.toml!
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata.docs.rs]
 features = ["doc"]


### PR DESCRIPTION
The PR prepares a HAL and RAL 0.4 release. We also release 0.1 of the IOMUXC crates with this release.