### PR TITLE
Exclude development files from RAL package

### DIFF
--- a/imxrt-ral/Cargo.toml
+++ b/imxrt-ral/Cargo.toml
@@ -10,11 +10,10 @@ keywords = ["imxrt", "nxp", "embedded", "no_std"]
 categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2018"
-exclude = [
-    "cortex_m/*",
-    "devices/*",
-    "scripts/*",
-    "svd/*",
+include = [
+    "src/*",
+    "build.rs",
+    "Cargo.toml",
 ]
 
 # Change version in imxrtral.py, not in Cargo.toml!

--- a/imxrt-ral/Cargo.toml
+++ b/imxrt-ral/Cargo.toml
@@ -10,6 +10,12 @@ keywords = ["imxrt", "nxp", "embedded", "no_std"]
 categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2018"
+exclude = [
+    "cortex_m/*",
+    "devices/*",
+    "scripts/*",
+    "svd/*",
+]
 
 # Change version in imxrtral.py, not in Cargo.toml!
 version = "0.3.0"

--- a/imxrt-ral/imxrtral.py
+++ b/imxrt-ral/imxrtral.py
@@ -61,11 +61,10 @@ keywords = ["imxrt", "nxp", "embedded", "no_std"]
 categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2018"
-exclude = [
-    "cortex_m/*",
-    "devices/*",
-    "scripts/*",
-    "svd/*",
+include = [
+    "src/*",
+    "build.rs",
+    "Cargo.toml",
 ]
 
 # Change version in imxrtral.py, not in Cargo.toml!

--- a/imxrt-ral/imxrtral.py
+++ b/imxrt-ral/imxrtral.py
@@ -61,6 +61,12 @@ keywords = ["imxrt", "nxp", "embedded", "no_std"]
 categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2018"
+exclude = [
+    "cortex_m/*",
+    "devices/*",
+    "scripts/*",
+    "svd/*",
+]
 
 # Change version in imxrtral.py, not in Cargo.toml!
 version = "0.3.0"


### PR DESCRIPTION
According to [crates.io](https://crates.io/crates/imxrt-ral), the 0.3.0 version of the RAL is 6.11 MB. `cargo package --list` shows that we're packaging the SVD files and YAML patches. The SVD files are large, and they're not necessary for crate users.

The PR excludes the SVDs, and all contents not necessary for compiling the crate, from the packaged crate.

I'm not sure how to perfectly replicate the crates.io size calculation, but I can see a smaller `.crate` file on my system. Size of the `.crate` file before this change:

```
$ cargo package --manifest-path imxrt-ral/Cargo.toml --target thumbv7em-none-eabihf --features rt --features imxrt1062
$ gzip -l target/package/imxrt-ral-0.3.0.crate
  compressed uncompressed  ratio uncompressed_name
     4051368     86374400  95.3% target/package/imxrt-ral-0.3.0.crate
```

Size of the `.crate` file with this change:

```
$ cargo package --manifest-path imxrt-ral/Cargo.toml --target thumbv7em-none-eabihf --features rt --features imxrt1062
$ gzip -l target/package/imxrt-ral-0.3.0.crate
  compressed uncompressed  ratio uncompressed_name
     1502316     19902464  92.4% target/package/imxrt-ral-0.3.0.crate
```