### PR TITLE
IOMUXC prelude

### DIFF
--- a/imxrt-iomuxc/Cargo.toml
+++ b/imxrt-iomuxc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imxrt-iomuxc"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ian McIntyre <ianpmcintyre@gmail.com>"]
 edition = "2018"
 description = """Pad configuration interface for NXP i.MX RT processors.

--- a/imxrt-iomuxc/src/lib.rs
+++ b/imxrt-iomuxc/src/lib.rs
@@ -117,7 +117,7 @@ pub mod prelude {
         configure, Config, DriveStrength, Hysteresis, OpenDrain, PullKeep, PullKeepSelect,
         PullUpDown, SlewRate, Speed,
     };
-    pub use crate::{consts, i2c, pwm, spi, uart};
+    pub use crate::{consts, gpio, i2c, pwm, spi, uart};
 }
 
 /// Type-level constants and traits

--- a/imxrt-iomuxc/src/lib.rs
+++ b/imxrt-iomuxc/src/lib.rs
@@ -97,6 +97,29 @@ pub use config::{
     SlewRate, Speed,
 };
 
+/// Re-export of top-level components, without the chip-specific modules.
+///
+/// `prelude` is to help HAL implementors re-export the `imxrt-iomuxc` APIs
+/// as a single module.
+///
+/// ```
+/// // Your crate's module:
+/// pub mod iomuxc {
+///     // Re-export common modules and types
+///     pub use imxrt_iomuxc::prelude::*;
+///     // Conditionally re-export chip-specific pads
+///     #[cfg(feature = "imxrt106x")]
+///     pub use imxrt_iomuxc::imxrt106x::*;
+/// }
+/// ```
+pub mod prelude {
+    pub use crate::config::{
+        configure, Config, DriveStrength, Hysteresis, OpenDrain, PullKeep, PullKeepSelect,
+        PullUpDown, SlewRate, Speed,
+    };
+    pub use crate::{consts, i2c, pwm, spi, uart};
+}
+
 /// Type-level constants and traits
 ///
 /// Re-exported from the [`typenum` crate](https://crates.io/crates/typenum), but scoped for the requirements

--- a/imxrt-iomuxc/src/lib.rs
+++ b/imxrt-iomuxc/src/lib.rs
@@ -117,7 +117,7 @@ pub mod prelude {
         configure, Config, DriveStrength, Hysteresis, OpenDrain, PullKeep, PullKeepSelect,
         PullUpDown, SlewRate, Speed,
     };
-    pub use crate::{consts, gpio, i2c, pwm, spi, uart};
+    pub use crate::{consts, gpio, i2c, pwm, spi, uart, Daisy, ErasedPad, Pad, WrongPadError};
 }
 
 /// Type-level constants and traits

--- a/imxrt-iomuxc/tests/prelude.rs
+++ b/imxrt-iomuxc/tests/prelude.rs
@@ -1,0 +1,24 @@
+//! Ensure that the `prelude` re-exports remain backwards compatible.
+//!
+//! If these tests do not compile, consider the API broken.
+
+#![allow(unused)]
+
+mod iomuxc {
+    #[cfg(feature = "imxrt106x")]
+    pub use imxrt_iomuxc::imxrt106x::*;
+    pub use imxrt_iomuxc::prelude::*;
+}
+
+/// Ensure that prelude modules are re-exported as expected
+#[test]
+fn use_prelude() {
+    use iomuxc::{consts, gpio, i2c, pwm, spi, uart};
+}
+
+/// Ensure that the imxrt106x modules are re-exported
+#[cfg(feature = "imxrt106x")]
+#[test]
+fn use_imxrt106x() {
+    use iomuxc::{ad_b0, ad_b1, b0, b1, emc, sd_b0, sd_b1, ErasedPads, Pads};
+}

--- a/imxrt-iomuxc/tests/prelude.rs
+++ b/imxrt-iomuxc/tests/prelude.rs
@@ -13,7 +13,7 @@ mod iomuxc {
 /// Ensure that prelude modules are re-exported as expected
 #[test]
 fn use_prelude() {
-    use iomuxc::{consts, gpio, i2c, pwm, spi, uart};
+    use iomuxc::{consts, gpio, i2c, pwm, spi, uart, Daisy, ErasedPad, Pad, WrongPadError};
 }
 
 /// Ensure that the imxrt106x modules are re-exported


### PR DESCRIPTION
The PR adds a small `prelude` module to the `imxrt-iomuxc` crate. `prelude` re-exports the general types and modules from the crate. It's to help HAL developers simply re-export the `imxrt-iomuxc` crate API without exposing the processor-specific IOMUXC module.

Today's usage in the HAL

https://github.com/imxrt-rs/imxrt-rs/blob/bd1b2df5afae5694ba71f33bc85e8fd349e358e7/imxrt-hal/src/lib.rs#L16-L27

produces [this API](https://docs.rs/imxrt-hal/0.4.0/imxrt_hal/iomuxc/index.html). The first `pub use imxrt_iomuxc::*;` statement includes a re-export of the `imxrt106x` module. We then re-export that module's interface through `pub use imxrt_iomuxc::imxrt106x::*;`. The end result is that the processor-specific types are reachable through the HAL's `iomuxc` module, and also the HAL's `iomuxc::imxrt106x` module, which is redundant.

Since the prelude contains everything *except* the processor-specific module, HAL implementers can do

```rust
pub mod iomuxc {
    // Re-export common modules and types
    pub use imxrt_iomuxc::prelude::*;
    // Conditionally re-export chip-specific pads
    #[cfg(feature = "imxrt106x")]
    pub use imxrt_iomuxc::imxrt106x::*;
}
```

without exposing the processor-specific module.