### PR TITLE
Maintain GPIO I/O configuration when enabling / disabling fast mode

### DIFF
--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fix
+
+- Maintain GPIO input/output configuration when enabling or disabling high-speed mode.
+
 ## [0.4.0] 2020-08-29
 
 This release contains numerous breaking HAL changes. See the "Changed" section for more information.

--- a/imxrt-hal/src/gpio.rs
+++ b/imxrt-hal/src/gpio.rs
@@ -105,8 +105,9 @@ where
     /// Returns `false` if this pin does not support fast mode. Otherwise, returns `true`, indicating
     /// that the setting was respected.
     ///
-    /// Note that the pin may be in a new state after transitioning into fast mode. Consider setting
-    /// and maintaining the fast mode setting before relying on the pin.
+    /// If you transition an output pin into fast mode, the GPIO output state may *not* be maintained.
+    /// That is, if your GPIO pin was high, a transition into fast mode may set the pin low. Consider
+    /// setting fast mode before driving the GPIO output to avoid inconsistencies.
     pub fn set_fast(&mut self, fast: bool) -> bool {
         self.gpr()
             .map(|gpr| {


### PR DESCRIPTION
The PR addresses an inconsistency when enabling / disabling GPIO fast mode. If the fix looks good, I'll prepare a 0.4.1 patch release of the HAL.

There are two valid ways to prepare a high-speed GPIO output:

```rust
pub fn configure_led(pad: LedPadType) -> LED {
    let mut led = hal::gpio::GPIO::new(pad);
    led.set_fast(true);
    led.output()
}
```

and

```rust
pub fn configure_led(pad: LedPadType) -> LED {
    let mut led = hal::gpio::GPIO::new(pad).output();
    led.set_fast(true);
    led
}
```

the former will put the GPIO into high-speed, or 'fast,' mode before setting 'output mode.' The latter will put the GPIO into output mode before fast mode.

After transitioning into fast mode, the GPIO will start to reference a different GPIO register block. The issue is that, after entering fast mode, the output / input state of the pin is not maintained. In the second snippet, the `set_fast(true)` call ends up reverting the GPIO state back to 'input,' since the newly-referenced register block does not maintain the same GPIO input / output configuration.

This PR updates the set_fast() method to maintain the GPIO I/O state for the new register block. It makes it so that either of the above patterns work.