### PR TITLE
Imxrt101x iomuxc

### DIFF
--- a/imxrt-iomuxc/Cargo.toml
+++ b/imxrt-iomuxc/Cargo.toml
@@ -20,6 +20,7 @@ imxrt-iomuxc-build = { version = "0.1.0", path = "imxrt-iomuxc-build" }
 
 [features]
 imxrt106x = []
+imxrt101x = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/imxrt-iomuxc/README.md
+++ b/imxrt-iomuxc/README.md
@@ -114,7 +114,7 @@ make it easier for the user.
 Since the approaches are equivalent, the change has no effect on a split i.MX RT HAL. An
 `imxrt-hal[-common]` crate would depend on the `imxrt-iomuxc` crate without feature flags.
 Then, a processor-specific HAL would depend on `imxrt-iomuxc` with the appropriate feature
-flag. We achive the goals of a split HAL, as users are unconcerned with feature flags.
+flag. We achieve the goals of a split HAL, as users are unconcerned with feature flags.
 
 We realize that this approach perpetuates the need for feature flags. However,
 the `imxrt-iomuxc` crate is a much lower-level interface than the HAL crates; it's equivalent

--- a/imxrt-iomuxc/src/imxrt101x/mod.rs
+++ b/imxrt-iomuxc/src/imxrt101x/mod.rs
@@ -1,0 +1,100 @@
+//! Pads for the i.MX RT 101x processor family
+//!
+//! The module exports all of the i.MX RT 101x processor's pads. Pads that can support peripheral
+//! functions are tagged with `imxrt-iomuxc` traits.
+//!
+//! # Example
+//!
+//! In the example below, we implement a hypothetical `uart_new` function, which is responsible
+//! for preparing a UART peripheral. To properly configure the peripheral, we need the two
+//! pads that represent a peripheral's TX and RX pins. The implementation will use the
+//! `imxrt_iomuxc::uart::prepare()` function to prepare the pins.
+//!
+//! Note the trait bounds on `uart_new`. The usage requires that
+//!
+//! - the user provides one TX and one RX pin
+//! - the modules for each pin match
+//!
+//! ```no_run
+//! use imxrt_iomuxc as iomuxc;
+//! use iomuxc::uart::{Pin, TX, RX};
+//!
+//! # struct UART;
+//! /// Creates a UART peripheral from the TX and RX pads, and a baud rate
+//! fn uart_new<T, R>(mut tx: T, mut rx: R, baud: u32) -> UART
+//! where
+//!     T: Pin<Direction = TX>,
+//!     R: Pin<Direction = RX, Module = <T as Pin>::Module>,
+//! {
+//!     // Check the imxrt-iomuxc documentation to understand why
+//!     // this is unsafe.
+//!     unsafe {
+//!         iomuxc::uart::prepare(&mut tx);
+//!         iomuxc::uart::prepare(&mut rx);
+//!     }
+//!     // Prepare the rest of the UART peripheral, and return it...
+//!     # UART
+//! }
+//!
+//! # let sd_12 = unsafe { imxrt_iomuxc::imxrt101x::sd::SD_12::new() };
+//! # let sd_11 = unsafe { imxrt_iomuxc::imxrt101x::sd::SD_11::new() };
+//! // SD_12 and SD_11 are a suitable pair of UART pins
+//! uart_new(sd_12, sd_11, 115_200);
+//! ```
+//!
+//! Specifically, the trait bounds guard against non-UART pins:
+//!
+//! ```compile_fail
+//! # use imxrt_iomuxc as iomuxc;
+//! # use iomuxc::uart::{Pin, TX, RX};
+//! # struct UART;
+//! # fn uart_new<T, R>(mut tx: T, mut rx: R, baud: u32) -> UART
+//! # where
+//! #     T: Pin<Direction = TX>,
+//! #     R: Pin<Direction = RX, Module = <T as Pin>::Module>,
+//! # {
+//! #     unsafe {
+//! #         iomuxc::uart::prepare(&mut tx);
+//! #         iomuxc::uart::prepare(&mut rx);
+//! #     }
+//! #     UART
+//! # }
+//! # let ad_10 = unsafe { imxrt_iomuxc::imxrt101x::ad::AD_10::new() };
+//! # let ad_11 = unsafe { imxrt_iomuxc::imxrt101x::ad::AD_11::new() };
+//! // Neither pad is a valid UART pin
+//! uart_new(ad_10, ad_11, 115_200);
+//! ```
+//!
+//! It also guards against mismatched UART pins:
+//!
+//! ```compile_fail
+//! # use imxrt_iomuxc as iomuxc;
+//! # use iomuxc::uart::{Pin, TX, RX};
+//! # struct UART;
+//! # fn uart_new<T, R>(mut tx: T, mut rx: R, baud: u32) -> UART
+//! # where
+//! #     T: Pin<Direction = TX>,
+//! #     R: Pin<Direction = RX, Module = <T as Pin>::Module>,
+//! # {
+//! #     unsafe {
+//! #         iomuxc::uart::prepare(&mut tx);
+//! #         iomuxc::uart::prepare(&mut rx);
+//! #     }
+//! #     UART
+//! # }
+//! # let gpio_09 = unsafe { imxrt_iomuxc::imxrt101x::gpio::GPIO_09::new() };
+//! # let gpio_13 = unsafe { imxrt_iomuxc::imxrt101x::gpio::GPIO_13::new() };
+//! // GPIO_10 is a UART1 TX pin, and GPIO_13 is a UART2 RX pin
+//! uart_new(gpio_10, gpio_13, 115_200);
+//! ```
+
+mod uart;
+
+include!(concat!(env!("OUT_DIR"), "/imxrt101x.rs"));
+pub use pads::*;
+
+mod bases {
+    define_base!(AD, 0x401F_8010, 0x401F_80C0);
+    define_base!(SD, 0x401F_804C, 0x401F_80FC);
+    define_base!(GPIO, 0x401F_8088, 0x401F_8138);
+}

--- a/imxrt-iomuxc/src/imxrt101x/uart.rs
+++ b/imxrt-iomuxc/src/imxrt101x/uart.rs
@@ -1,0 +1,176 @@
+//! UART pin implementations
+
+use super::pads::{ad::*, gpio::*, sd::*};
+use crate::{
+    consts::*,
+    uart::{Pin, RX, TX},
+    Daisy,
+};
+
+//
+// UART1
+//
+
+impl Pin for GPIO_09 {
+    const ALT: u32 = 0;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART1_RXD_09);
+    type Direction = RX;
+    type Module = U1;
+}
+
+impl Pin for SD_11 {
+    const ALT: u32 = 2;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART1_RXD_SD_11);
+    type Direction = RX;
+    type Module = U1;
+}
+
+impl Pin for GPIO_10 {
+    const ALT: u32 = 0;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART1_TXD_10);
+    type Direction = TX;
+    type Module = U1;
+}
+
+impl Pin for SD_12 {
+    const ALT: u32 = 2;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART1_TXD_SD_12);
+    type Direction = TX;
+    type Module = U1;
+}
+
+//
+// UART2
+//
+
+impl Pin for GPIO_13 {
+    const ALT: u32 = 0;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART2_RXD_13);
+    type Direction = RX;
+    type Module = U2;
+}
+
+impl Pin for SD_09 {
+    const ALT: u32 = 2;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART2_RXD_SD_09);
+    type Direction = RX;
+    type Module = U2;
+}
+
+impl Pin for AD_00 {
+    const ALT: u32 = 0;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART2_TXD_AD_00);
+    type Direction = TX;
+    type Module = U2;
+}
+
+impl Pin for SD_10 {
+    const ALT: u32 = 2;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART2_TXD_SD_10);
+    type Direction = TX;
+    type Module = U2;
+}
+
+//
+// UART3
+//
+
+impl Pin for GPIO_11 {
+    const ALT: u32 = 0;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART3_RXD_11);
+    type Direction = RX;
+    type Module = U3;
+}
+
+impl Pin for AD_07 {
+    const ALT: u32 = 1;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART3_RXD_AD_07);
+    type Direction = RX;
+    type Module = U3;
+}
+
+impl Pin for GPIO_07 {
+    const ALT: u32 = 3;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART3_RXD_07);
+    type Direction = RX;
+    type Module = U3;
+}
+
+impl Pin for GPIO_12 {
+    const ALT: u32 = 0;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART3_TXD_12);
+    type Direction = TX;
+    type Module = U3;
+}
+
+impl Pin for AD_08 {
+    const ALT: u32 = 1;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART3_TXD_AD_08);
+    type Direction = TX;
+    type Module = U3;
+}
+
+impl Pin for GPIO_08 {
+    const ALT: u32 = 3;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART3_TXD_08);
+    type Direction = TX;
+    type Module = U3;
+}
+
+//
+// UART4
+//
+
+impl Pin for AD_01 {
+    const ALT: u32 = 0;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART4_RXD_AD_01);
+    type Direction = RX;
+    type Module = U4;
+}
+
+impl Pin for GPIO_05 {
+    const ALT: u32 = 3;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART4_RXD_05);
+    type Direction = RX;
+    type Module = U4;
+}
+
+impl Pin for AD_02 {
+    const ALT: u32 = 0;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART4_TXD_AD_02);
+    type Direction = TX;
+    type Module = U4;
+}
+
+impl Pin for GPIO_06 {
+    const ALT: u32 = 3;
+    const DAISY: Option<Daisy> = Some(DAISY_LPUART4_TXD_06);
+    type Direction = TX;
+    type Module = U4;
+}
+
+/// Auto-generated Daisy constants
+mod daisy {
+    #![allow(unused)]
+    use super::Daisy;
+
+    pub const DAISY_LPUART1_RXD_SD_11: Daisy = Daisy::new(0x401f81f0 as *mut u32, 0);
+    pub const DAISY_LPUART1_RXD_09: Daisy = Daisy::new(0x401f81f0 as *mut u32, 1);
+    pub const DAISY_LPUART1_TXD_SD_12: Daisy = Daisy::new(0x401f81f4 as *mut u32, 0);
+    pub const DAISY_LPUART1_TXD_10: Daisy = Daisy::new(0x401f81f4 as *mut u32, 1);
+    pub const DAISY_LPUART2_RXD_SD_09: Daisy = Daisy::new(0x401f81f8 as *mut u32, 0);
+    pub const DAISY_LPUART2_RXD_13: Daisy = Daisy::new(0x401f81f8 as *mut u32, 1);
+    pub const DAISY_LPUART2_TXD_AD_00: Daisy = Daisy::new(0x401f81fc as *mut u32, 0);
+    pub const DAISY_LPUART2_TXD_SD_10: Daisy = Daisy::new(0x401f81fc as *mut u32, 1);
+    pub const DAISY_LPUART3_RXD_AD_07: Daisy = Daisy::new(0x401f8200 as *mut u32, 0);
+    pub const DAISY_LPUART3_RXD_11: Daisy = Daisy::new(0x401f8200 as *mut u32, 1);
+    pub const DAISY_LPUART3_RXD_07: Daisy = Daisy::new(0x401f8200 as *mut u32, 2);
+    pub const DAISY_LPUART3_TXD_AD_08: Daisy = Daisy::new(0x401f8204 as *mut u32, 0);
+    pub const DAISY_LPUART3_TXD_12: Daisy = Daisy::new(0x401f8204 as *mut u32, 1);
+    pub const DAISY_LPUART3_TXD_08: Daisy = Daisy::new(0x401f8204 as *mut u32, 2);
+    pub const DAISY_LPUART4_RXD_AD_01: Daisy = Daisy::new(0x401f8208 as *mut u32, 0);
+    pub const DAISY_LPUART4_RXD_05: Daisy = Daisy::new(0x401f8208 as *mut u32, 1);
+    pub const DAISY_LPUART4_TXD_AD_02: Daisy = Daisy::new(0x401f820c as *mut u32, 0);
+    pub const DAISY_LPUART4_TXD_06: Daisy = Daisy::new(0x401f820c as *mut u32, 1);
+}
+use daisy::*;

--- a/imxrt-iomuxc/src/lib.rs
+++ b/imxrt-iomuxc/src/lib.rs
@@ -189,6 +189,9 @@ macro_rules! define_base {
 // Listing the processor modules here, since they may depend on the
 // above `define_base!()` macro...
 //
+#[cfg(feature = "imxrt101x")]
+#[cfg_attr(docsrs, doc(cfg(feature = "imxrt101x")))]
+pub mod imxrt101x;
 
 #[cfg(feature = "imxrt106x")]
 #[cfg_attr(docsrs, doc(cfg(feature = "imxrt106x")))]


### PR DESCRIPTION
Adds the basic uart pin defs and beginnings of the imxrt101x iomux stuff to the repo

I ran into an annoyance in that the build (cargo build) in the project root fails in imxrt-hal if I don't specify imxrt1062 as default feature, I need to check the master branch again here first if that's how it was (been a bit since I did stuff!)

It's a nice feeling when you can git clone and cargo build though so maybe there's a nicer way of doing this or maybe this won't be an issue when I split the imxrt-hal stuff up more