### PR TITLE
DMA support for all chip variants

### DIFF
--- a/imxrt-hal/src/dma.rs
+++ b/imxrt-hal/src/dma.rs
@@ -474,7 +474,7 @@ impl Unclocked {
     /// Enable the clocks for the DMA peripheral
     ///
     /// The return is an array of 32 channels. However, **only the first [`CHANNEL_COUNT`](constant.CHANNEL_COUNT.html) channels
-    /// are initialized to `Some(channel)`. The rest are `None`.
+    /// are initialized to `Some(channel)`. The rest are `None`.**
     ///
     /// Users may take channels as needed. The index in the array maps to the DMA channel number.
     pub fn clock(mut self, ccm: &mut ccm::Handle) -> [Option<Channel>; 32] {

--- a/imxrt-hal/src/dma.rs
+++ b/imxrt-hal/src/dma.rs
@@ -160,7 +160,7 @@ pub(crate) mod peripheral;
 mod register;
 
 pub use buffer::{Buffer, Circular, CircularError, Drain, Linear, ReadHalf, WriteHalf};
-pub use chip::DMA_CHANNEL_COUNT;
+pub use chip::CHANNEL_COUNT;
 pub use element::Element;
 pub use memcpy::Memcpy;
 pub use peripheral::{helpers::*, Peripheral};
@@ -183,7 +183,7 @@ use register::{DMARegisters, MultiplexerRegisters, Static, DMA, MULTIPLEXER};
 /// DMA channels have very little public interface. They're best used when paired with a
 /// [`Peripheral`](struct.Peripheral.html) or a [`Memcpy`](struct.Memcpy.html).
 pub struct Channel {
-    /// Our channel number, expected to be between 0 and (DMA_CHANNEL_COUNT - 1)
+    /// Our channel number, expected to be between 0 and (CHANNEL_COUNT - 1)
     index: usize,
     /// Reference to the DMA registers
     registers: Static<DMARegisters>,
@@ -207,7 +207,7 @@ impl Channel {
 
     /// Returns the DMA channel number
     ///
-    /// Channels are unique and numbered within the half-open range `[0, DMA_CHANNEL_COUNT)`.
+    /// Channels are unique and numbered within the half-open range `[0, CHANNEL_COUNT)`.
     pub fn channel(&self) -> usize {
         self.index
     }
@@ -459,7 +459,7 @@ pub enum Error<P> {
 /// let channel_27 = dma_channels[27].take().unwrap();
 /// let channel_0 = dma_channels[0].take().unwrap();
 /// ```
-pub struct Unclocked([Option<Channel>; DMA_CHANNEL_COUNT]);
+pub struct Unclocked([Option<Channel>; CHANNEL_COUNT]);
 impl Unclocked {
     pub(crate) fn new(dma: ral::dma0::Instance, mux: ral::dmamux::Instance) -> Self {
         // Explicitly dropping instances
@@ -473,9 +473,9 @@ impl Unclocked {
     }
     /// Enable the clocks for the DMA peripheral
     ///
-    /// The return is `DMA_CHANNEL_COUNT` channels, each being initialized as `Some(Channel)`. Users may take channels as needed.
+    /// The return is `CHANNEL_COUNT` channels, each being initialized as `Some(Channel)`. Users may take channels as needed.
     /// The index in the array maps to the DMA channel number.
-    pub fn clock(mut self, ccm: &mut ccm::Handle) -> [Option<Channel>; DMA_CHANNEL_COUNT] {
+    pub fn clock(mut self, ccm: &mut ccm::Handle) -> [Option<Channel>; CHANNEL_COUNT] {
         let (ccm, _) = ccm.raw();
         ral::modify_reg!(ral::ccm, ccm, CCGR5, CG3: 0x03);
         for (idx, channel) in self.0.iter_mut().enumerate() {

--- a/imxrt-hal/src/dma.rs
+++ b/imxrt-hal/src/dma.rs
@@ -473,12 +473,14 @@ impl Unclocked {
     }
     /// Enable the clocks for the DMA peripheral
     ///
-    /// The return is `CHANNEL_COUNT` channels, each being initialized as `Some(Channel)`. Users may take channels as needed.
-    /// The index in the array maps to the DMA channel number.
-    pub fn clock(mut self, ccm: &mut ccm::Handle) -> [Option<Channel>; CHANNEL_COUNT] {
+    /// The return is an array of 32 channels. However, **only the first [`CHANNEL_COUNT`](constant.CHANNEL_COUNT.html) channels
+    /// are initialized to `Some(channel)`. The rest are `None`.
+    ///
+    /// Users may take channels as needed. The index in the array maps to the DMA channel number.
+    pub fn clock(mut self, ccm: &mut ccm::Handle) -> [Option<Channel>; 32] {
         let (ccm, _) = ccm.raw();
         ral::modify_reg!(ral::ccm, ccm, CCGR5, CG3: 0x03);
-        for (idx, channel) in self.0.iter_mut().enumerate() {
+        for (idx, channel) in self.0.iter_mut().take(CHANNEL_COUNT).enumerate() {
             *channel = Some(Channel::new(idx));
         }
         self.0

--- a/imxrt-hal/src/dma/chip.rs
+++ b/imxrt-hal/src/dma/chip.rs
@@ -16,23 +16,25 @@ use core::fmt::{self, Display};
 //
 
 /// The number of DMA channels
+///
+/// This varies depending on the i.MX RT processor variant. Consult your
+/// reference manual for more information.
 #[cfg(feature = "imxrt1011")]
 pub const CHANNEL_COUNT: usize = 16;
 
 /// The number of DMA channels
+///
+/// This varies depending on the i.MX RT processor variant. Consult your
+/// reference manual for more information.
 #[cfg(not(feature = "imxrt1011"))]
 pub const CHANNEL_COUNT: usize = 32;
 
 /// Helper symbol to support DMA channel initialization
-#[cfg(not(feature = "imxrt1011"))]
-pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; CHANNEL_COUNT] = [
+///
+/// We always provide users with an array of 32 channels. But, only the first `CHANNEL_COUNT`
+/// channels are initialized.
+pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; 32] = [
     None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-];
-
-/// Helper symbol to support DMA channel initialization
-#[cfg(feature = "imxrt1011")]
-pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; CHANNEL_COUNT] = [
     None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
 ];
 

--- a/imxrt-hal/src/dma/chip.rs
+++ b/imxrt-hal/src/dma/chip.rs
@@ -17,22 +17,22 @@ use core::fmt::{self, Display};
 
 /// The number of DMA channels
 #[cfg(feature = "imxrt1011")]
-pub const DMA_CHANNEL_COUNT: usize = 16;
+pub const CHANNEL_COUNT: usize = 16;
 
 /// The number of DMA channels
 #[cfg(not(feature = "imxrt1011"))]
-pub const DMA_CHANNEL_COUNT: usize = 32;
+pub const CHANNEL_COUNT: usize = 32;
 
 /// Helper symbol to support DMA channel initialization
 #[cfg(not(feature = "imxrt1011"))]
-pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; DMA_CHANNEL_COUNT] = [
+pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; CHANNEL_COUNT] = [
     None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
     None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
 ];
 
 /// Helper symbol to support DMA channel initialization
 #[cfg(feature = "imxrt1011")]
-pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; DMA_CHANNEL_COUNT] = [
+pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; CHANNEL_COUNT] = [
     None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
 ];
 

--- a/imxrt-hal/src/dma/chip.rs
+++ b/imxrt-hal/src/dma/chip.rs
@@ -16,27 +16,16 @@ use core::fmt::{self, Display};
 //
 
 /// The number of DMA channels
-#[cfg(any(feature = "imxrt1011"))]
+#[cfg(feature = "imxrt1011")]
 pub const DMA_CHANNEL_COUNT: usize = 16;
 
 /// The number of DMA channels
-#[cfg(any(feature = "imxrt1062"))]
+#[cfg(not(feature = "imxrt1011"))]
 pub const DMA_CHANNEL_COUNT: usize = 32;
-
-/// When adding support for a new chip, make sure to either
-///
-/// - update an existing DMA_CHANNEL_COUNT above, or
-/// - create a new DMA_CHANNEL_COUNT constant
-///
-/// When you add that new chip feature, you should also add
-/// it to this list.
-#[cfg(not(any(feature = "imxrt1011", feature = "imxrt1062",)))]
-pub const DMA_CHANNEL_COUNT: usize =
-    compile_error!("No DMA_CHANNEL_COUNT specified for this chip!");
 
 
 /// Helper symbol to support DMA channel initialization
-#[cfg(any(feature = "imxrt1062"))]
+#[cfg(not(feature = "imxrt1011"))]
 pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; DMA_CHANNEL_COUNT] = [
     None, None, None, None, None, None, None, None, None, None, None, None, None, None,
     None, None, None, None, None, None, None, None, None, None, None, None, None, None,
@@ -44,22 +33,18 @@ pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; DMA_CHANNEL_COUNT] =
 ];
 
 /// Helper symbol to support DMA channel initialization
-#[cfg(any(feature = "imxrt1011"))]
+#[cfg(feature = "imxrt1011")]
 pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; DMA_CHANNEL_COUNT] = [
     None, None, None, None, None, None, None, None, None, None, None, None, None, None,
     None, None,
 ];
-
-#[cfg(not(any(feature = "imxrt1011", feature = "imxrt1062")))]
-pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; DMA_CHANNEL_COUNT] =
-    compile_error!("No DMA_CHANNEL_INIT specified for this chip!");
 
 //
 // Conditionally display group priority errors (GPE), and handle
 // different masks for error channel (ERRCHN)
 //
 
-#[cfg(any(feature = "imxrt1011"))]
+#[cfg(feature = "imxrt1011")]
 impl Display for ErrorStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
@@ -81,7 +66,7 @@ impl Display for ErrorStatus {
     }
 }
 
-#[cfg(any(feature = "imxrt1062"))]
+#[cfg(not(feature = "imxrt1011"))]
 impl Display for ErrorStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f,
@@ -100,12 +85,5 @@ impl Display for ErrorStatus {
             sbe = (self.es >> 1) & 0x1,
             dbe = self.es & 0x1
         )
-    }
-}
-
-#[cfg(not(any(feature = "imxrt1011", feature = "imxrt1062",)))]
-impl Display for ErrorStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        compile_error!("No 'impl Display for ErrorStatus' specified for this chip!")
     }
 }

--- a/imxrt-hal/src/dma/chip.rs
+++ b/imxrt-hal/src/dma/chip.rs
@@ -92,6 +92,6 @@ impl Display for ErrorStatus {
 //
 
 /// Address to the DMA multiplexer registers
-pub(crate) const DMA_MULTIPLEXER_ADDRESS: u32 = 0x400E_C000;
+pub(crate) const DMA_MULTIPLEXER_ADDRESS: *const u32 = 0x400E_C000 as *const _;
 /// Address to the DMA peripheral registers
-pub(crate) const DMA_ADDRESS: u32 = 0x400E_8000;
+pub(crate) const DMA_ADDRESS: *const u32 = 0x400E_8000 as *const _;

--- a/imxrt-hal/src/dma/chip.rs
+++ b/imxrt-hal/src/dma/chip.rs
@@ -23,20 +23,17 @@ pub const DMA_CHANNEL_COUNT: usize = 16;
 #[cfg(not(feature = "imxrt1011"))]
 pub const DMA_CHANNEL_COUNT: usize = 32;
 
-
 /// Helper symbol to support DMA channel initialization
 #[cfg(not(feature = "imxrt1011"))]
 pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; DMA_CHANNEL_COUNT] = [
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
 ];
 
 /// Helper symbol to support DMA channel initialization
 #[cfg(feature = "imxrt1011")]
 pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; DMA_CHANNEL_COUNT] = [
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
 ];
 
 //
@@ -87,3 +84,14 @@ impl Display for ErrorStatus {
         )
     }
 }
+
+//
+// These don't vary across chips.
+// They're only in this module to
+// show that we thought about that.
+//
+
+/// Address to the DMA multiplexer registers
+pub(crate) const DMA_MULTIPLEXER_ADDRESS: u32 = 0x400E_C000;
+/// Address to the DMA peripheral registers
+pub(crate) const DMA_ADDRESS: u32 = 0x400E_8000;

--- a/imxrt-hal/src/dma/chip.rs
+++ b/imxrt-hal/src/dma/chip.rs
@@ -1,0 +1,111 @@
+//! The DMA chip module contains any DMA configurations that are
+//! particular for a i.MX RT chip or chip family
+//!
+//! Things that are known to differ:
+//!
+//! - DMA channels
+//! - Availability of DMA channel grouping, group scheduling, and error indications. As
+//!   of this writing, DMA channel grouping and group scheduling is not implemented, so
+//!   we can ignore that for now. We vary the way we display `ErrorStatus` messages.
+
+use super::ErrorStatus;
+use core::fmt::{self, Display};
+
+//
+// Specify the DMA channel count
+//
+
+/// The number of DMA channels
+#[cfg(any(feature = "imxrt1011"))]
+pub const DMA_CHANNEL_COUNT: usize = 16;
+
+/// The number of DMA channels
+#[cfg(any(feature = "imxrt1062"))]
+pub const DMA_CHANNEL_COUNT: usize = 32;
+
+/// When adding support for a new chip, make sure to either
+///
+/// - update an existing DMA_CHANNEL_COUNT above, or
+/// - create a new DMA_CHANNEL_COUNT constant
+///
+/// When you add that new chip feature, you should also add
+/// it to this list.
+#[cfg(not(any(feature = "imxrt1011", feature = "imxrt1062",)))]
+pub const DMA_CHANNEL_COUNT: usize =
+    compile_error!("No DMA_CHANNEL_COUNT specified for this chip!");
+
+
+/// Helper symbol to support DMA channel initialization
+#[cfg(any(feature = "imxrt1062"))]
+pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; DMA_CHANNEL_COUNT] = [
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None,
+];
+
+/// Helper symbol to support DMA channel initialization
+#[cfg(any(feature = "imxrt1011"))]
+pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; DMA_CHANNEL_COUNT] = [
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None,
+];
+
+#[cfg(not(any(feature = "imxrt1011", feature = "imxrt1062")))]
+pub(crate) const DMA_CHANNEL_INIT: [Option<super::Channel>; DMA_CHANNEL_COUNT] =
+    compile_error!("No DMA_CHANNEL_INIT specified for this chip!");
+
+//
+// Conditionally display group priority errors (GPE), and handle
+// different masks for error channel (ERRCHN)
+//
+
+#[cfg(any(feature = "imxrt1011"))]
+impl Display for ErrorStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+            "DMA_ES: VLD {vld} ECX {ecx} CPE {cpe} ERRCHN {errchn} SAE {sae} SOE {soe} DAE {dae} DOE {doe} NCE {nce} SGE {sge} SBE {sbe} DBE {dbe}",
+            vld = (self.es >> 31) & 0x1,
+            ecx = (self.es >> 16) & 0x1,
+            // No GPE
+            cpe = (self.es >> 14) & 0x1,
+            errchn = (self.es >> 8) & 0x0F, // Four bits for error channel
+            sae = (self.es >> 7) & 0x1,
+            soe = (self.es >> 6) & 0x1,
+            dae = (self.es >> 5) & 0x1,
+            doe = (self.es >> 4) & 0x1,
+            nce = (self.es >> 3) & 0x1,
+            sge = (self.es >> 2) & 0x1,
+            sbe = (self.es >> 1) & 0x1,
+            dbe = self.es & 0x1
+        )
+    }
+}
+
+#[cfg(any(feature = "imxrt1062"))]
+impl Display for ErrorStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,
+            "DMA_ES: VLD {vld} ECX {ecx} GPE {gpe} CPE {cpe} ERRCHN {errchn} SAE {sae} SOE {soe} DAE {dae} DOE {doe} NCE {nce} SGE {sge} SBE {sbe} DBE {dbe}",
+            vld = (self.es >> 31) & 0x1,
+            ecx = (self.es >> 16) & 0x1,
+            gpe = (self.es >> 15) & 0x1,
+            cpe = (self.es >> 14) & 0x1,
+            errchn = (self.es >> 8) & 0x1F, // Five bits for error channel
+            sae = (self.es >> 7) & 0x1,
+            soe = (self.es >> 6) & 0x1,
+            dae = (self.es >> 5) & 0x1,
+            doe = (self.es >> 4) & 0x1,
+            nce = (self.es >> 3) & 0x1,
+            sge = (self.es >> 2) & 0x1,
+            sbe = (self.es >> 1) & 0x1,
+            dbe = self.es & 0x1
+        )
+    }
+}
+
+#[cfg(not(any(feature = "imxrt1011", feature = "imxrt1062",)))]
+impl Display for ErrorStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        compile_error!("No 'impl Display for ErrorStatus' specified for this chip!")
+    }
+}

--- a/imxrt-hal/src/dma/register.rs
+++ b/imxrt-hal/src/dma/register.rs
@@ -16,7 +16,7 @@ use core::ops::Index;
 #[repr(C)]
 pub(super) struct MultiplexerRegisters {
     /// Multiplexer configuration registers, one per channel
-    pub chcfg: [RWRegister<u32>; 32],
+    pub chcfg: [RWRegister<u32>; super::DMA_CHANNEL_COUNT],
 }
 
 pub(super) const MULTIPLEXER: Static<MultiplexerRegisters> = Static(0x400E_C000 as *const _);
@@ -72,7 +72,7 @@ pub(super) struct DMARegisters {
     pub DCHPRI: ChannelPriorityRegisters,
     _reserved8: [u32; 952],
     /// Transfer Control Descriptors
-    pub TCD: [TransferControlDescriptor; 32],
+    pub TCD: [TransferControlDescriptor; super::DMA_CHANNEL_COUNT],
 }
 
 pub(super) const DMA: Static<DMARegisters> = Static(0x400E_8000 as *const _);

--- a/imxrt-hal/src/dma/register.rs
+++ b/imxrt-hal/src/dma/register.rs
@@ -16,7 +16,7 @@ use core::ops::Index;
 #[repr(C)]
 pub(super) struct MultiplexerRegisters {
     /// Multiplexer configuration registers, one per channel
-    pub chcfg: [RWRegister<u32>; super::DMA_CHANNEL_COUNT],
+    pub chcfg: [RWRegister<u32>; super::CHANNEL_COUNT],
 }
 
 pub(super) const MULTIPLEXER: Static<MultiplexerRegisters> =
@@ -73,7 +73,7 @@ pub(super) struct DMARegisters {
     pub DCHPRI: ChannelPriorityRegisters,
     _reserved8: [u32; 952],
     /// Transfer Control Descriptors
-    pub TCD: [TransferControlDescriptor; super::DMA_CHANNEL_COUNT],
+    pub TCD: [TransferControlDescriptor; super::CHANNEL_COUNT],
 }
 
 pub(super) const DMA: Static<DMARegisters> = Static(super::chip::DMA_ADDRESS as *const _);
@@ -86,7 +86,7 @@ pub(super) const DMA: Static<DMARegisters> = Static(super::chip::DMA_ADDRESS as 
 /// the channel number to a reference to the priority
 /// register.
 #[repr(transparent)]
-pub(super) struct ChannelPriorityRegisters([RWRegister<u8>; 32]);
+pub(super) struct ChannelPriorityRegisters([RWRegister<u8>; super::CHANNEL_COUNT]);
 
 impl Index<usize> for ChannelPriorityRegisters {
     type Output = RWRegister<u8>;

--- a/imxrt-hal/src/dma/register.rs
+++ b/imxrt-hal/src/dma/register.rs
@@ -19,7 +19,8 @@ pub(super) struct MultiplexerRegisters {
     pub chcfg: [RWRegister<u32>; super::DMA_CHANNEL_COUNT],
 }
 
-pub(super) const MULTIPLEXER: Static<MultiplexerRegisters> = Static(0x400E_C000 as *const _);
+pub(super) const MULTIPLEXER: Static<MultiplexerRegisters> =
+    Static(super::chip::DMA_MULTIPLEXER_ADDRESS as *const _);
 
 impl MultiplexerRegisters {
     pub const ENBL: u32 = 1 << 31;
@@ -75,7 +76,7 @@ pub(super) struct DMARegisters {
     pub TCD: [TransferControlDescriptor; super::DMA_CHANNEL_COUNT],
 }
 
-pub(super) const DMA: Static<DMARegisters> = Static(0x400E_8000 as *const _);
+pub(super) const DMA: Static<DMARegisters> = Static(super::chip::DMA_ADDRESS as *const _);
 
 /// Wrapper for channel priority registers
 ///


### PR DESCRIPTION
The PR provides DMA support for all chip variants. DMA support is probably lower on #56's TODO list. However, the DMA implementation is more unique than the other peripherals: the RAL interface was hand-written. Hand-writing the RAL was necessary for providing a simpler API, since the `svd2ral` script generated a lot of symbols.

I arrived at this implementation by studying the reference manuals. In summary, the 1011 chip only has 16 DMA channels; chips that are 1015 and higher hav 32 DMA channels. When you have more than 16 DMA channels, you have the option for channel grouping. Today's DMA driver doesn't support channel grouping, so this is only a comment in the code.

The conditional compiles are hidden behind a new `chip` module, private to the DMA driver. We use the common symbols from the `chip` module throughout the implementation.

This is a backwards-compatible change, at least in the short term. We now export a new constant, `CHANNEL_COUNT`, which signals the number of DMA channels supported in the implementation. Crate users should favor that constant instead of hard-coded `32`s.