### PR TITLE
IOMUXC: Add I2C, SPI traits for 1011 pads

### DIFF
--- a/imxrt-iomuxc/src/imxrt101x/i2c.rs
+++ b/imxrt-iomuxc/src/imxrt101x/i2c.rs
@@ -1,0 +1,161 @@
+//! I2C pin implementations
+
+use super::pads::{ad::*, gpio::*, sd::*};
+use crate::{
+    consts::*,
+    i2c::{Pin, SCL, SDA},
+    Daisy,
+};
+
+//
+// I2C1
+//
+
+// SCL
+
+impl Pin for AD_14 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPI2C1_SCL_AD_14;
+    type Signal = SCL;
+    type Module = U1;
+}
+
+impl Pin for SD_06 {
+    const ALT: u32 = 1;
+    const DAISY: Daisy = DAISY_LPI2C1_SCL_SD_06;
+    type Signal = SCL;
+    type Module = U1;
+}
+
+impl Pin for GPIO_12 {
+    const ALT: u32 = 1;
+    const DAISY: Daisy = DAISY_LPI2C1_SCL_12;
+    type Signal = SCL;
+    type Module = U1;
+}
+
+impl Pin for GPIO_02 {
+    const ALT: u32 = 3;
+    const DAISY: Daisy = DAISY_LPI2C1_SCL_02;
+    type Signal = SCL;
+    type Module = U1;
+}
+
+// SDA
+
+impl Pin for AD_13 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPI2C1_SDA_AD_13;
+    type Signal = SDA;
+    type Module = U1;
+}
+
+impl Pin for SD_05 {
+    const ALT: u32 = 1;
+    const DAISY: Daisy = DAISY_LPI2C1_SDA_SD_05;
+    type Signal = SDA;
+    type Module = U1;
+}
+
+impl Pin for GPIO_11 {
+    const ALT: u32 = 1;
+    const DAISY: Daisy = DAISY_LPI2C1_SDA_11;
+    type Signal = SDA;
+    type Module = U1;
+}
+
+impl Pin for GPIO_01 {
+    const ALT: u32 = 3;
+    const DAISY: Daisy = DAISY_LPI2C1_SDA_01;
+    type Signal = SDA;
+    type Module = U1;
+}
+
+//
+// I2C2
+//
+
+// SCL
+
+impl Pin for AD_08 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPI2C2_SCL_AD_08;
+    type Signal = SCL;
+    type Module = U2;
+}
+
+impl Pin for SD_08 {
+    const ALT: u32 = 1;
+    const DAISY: Daisy = DAISY_LPI2C2_SCL_SD_08;
+    type Signal = SCL;
+    type Module = U2;
+}
+
+impl Pin for AD_02 {
+    const ALT: u32 = 3;
+    const DAISY: Daisy = DAISY_LPI2C2_SCL_AD_02;
+    type Signal = SCL;
+    type Module = U2;
+}
+
+impl Pin for GPIO_10 {
+    const ALT: u32 = 3;
+    const DAISY: Daisy = DAISY_LPI2C2_SCL_10;
+    type Signal = SCL;
+    type Module = U2;
+}
+
+// SDA
+
+impl Pin for AD_07 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPI2C2_SDA_AD_07;
+    type Signal = SDA;
+    type Module = U2;
+}
+
+impl Pin for SD_07 {
+    const ALT: u32 = 1;
+    const DAISY: Daisy = DAISY_LPI2C2_SDA_SD_07;
+    type Signal = SDA;
+    type Module = U2;
+}
+
+impl Pin for AD_01 {
+    const ALT: u32 = 3;
+    const DAISY: Daisy = DAISY_LPI2C2_SDA_AD_01;
+    type Signal = SDA;
+    type Module = U2;
+}
+
+impl Pin for GPIO_09 {
+    const ALT: u32 = 3;
+    const DAISY: Daisy = DAISY_LPI2C2_SDA_09;
+    type Signal = SDA;
+    type Module = U2;
+}
+
+mod daisy {
+    #![allow(unused)]
+
+    use super::Daisy;
+    pub const DAISY_LPI2C1_HREQ_AD_06: Daisy = Daisy::new(0x401f81bc as *mut u32, 0);
+    pub const DAISY_LPI2C1_HREQ_10: Daisy = Daisy::new(0x401f81bc as *mut u32, 1);
+    pub const DAISY_LPI2C1_SCL_AD_14: Daisy = Daisy::new(0x401f81c0 as *mut u32, 0);
+    pub const DAISY_LPI2C1_SCL_SD_06: Daisy = Daisy::new(0x401f81c0 as *mut u32, 1);
+    pub const DAISY_LPI2C1_SCL_12: Daisy = Daisy::new(0x401f81c0 as *mut u32, 2);
+    pub const DAISY_LPI2C1_SCL_02: Daisy = Daisy::new(0x401f81c0 as *mut u32, 3);
+    pub const DAISY_LPI2C1_SDA_AD_13: Daisy = Daisy::new(0x401f81c4 as *mut u32, 0);
+    pub const DAISY_LPI2C1_SDA_SD_05: Daisy = Daisy::new(0x401f81c4 as *mut u32, 1);
+    pub const DAISY_LPI2C1_SDA_11: Daisy = Daisy::new(0x401f81c4 as *mut u32, 2);
+    pub const DAISY_LPI2C1_SDA_01: Daisy = Daisy::new(0x401f81c4 as *mut u32, 3);
+    pub const DAISY_LPI2C2_SCL_AD_08: Daisy = Daisy::new(0x401f81c8 as *mut u32, 0);
+    pub const DAISY_LPI2C2_SCL_AD_02: Daisy = Daisy::new(0x401f81c8 as *mut u32, 1);
+    pub const DAISY_LPI2C2_SCL_SD_08: Daisy = Daisy::new(0x401f81c8 as *mut u32, 2);
+    pub const DAISY_LPI2C2_SCL_10: Daisy = Daisy::new(0x401f81c8 as *mut u32, 3);
+    pub const DAISY_LPI2C2_SDA_AD_07: Daisy = Daisy::new(0x401f81cc as *mut u32, 0);
+    pub const DAISY_LPI2C2_SDA_AD_01: Daisy = Daisy::new(0x401f81cc as *mut u32, 1);
+    pub const DAISY_LPI2C2_SDA_SD_07: Daisy = Daisy::new(0x401f81cc as *mut u32, 2);
+    pub const DAISY_LPI2C2_SDA_09: Daisy = Daisy::new(0x401f81cc as *mut u32, 3);
+}
+use daisy::*;

--- a/imxrt-iomuxc/src/imxrt101x/mod.rs
+++ b/imxrt-iomuxc/src/imxrt101x/mod.rs
@@ -89,6 +89,7 @@
 //! ```
 
 mod i2c;
+mod spi;
 mod uart;
 
 include!(concat!(env!("OUT_DIR"), "/imxrt101x.rs"));

--- a/imxrt-iomuxc/src/imxrt101x/mod.rs
+++ b/imxrt-iomuxc/src/imxrt101x/mod.rs
@@ -88,6 +88,7 @@
 //! uart_new(gpio_10, gpio_13, 115_200);
 //! ```
 
+mod i2c;
 mod uart;
 
 include!(concat!(env!("OUT_DIR"), "/imxrt101x.rs"));

--- a/imxrt-iomuxc/src/imxrt101x/spi.rs
+++ b/imxrt-iomuxc/src/imxrt101x/spi.rs
@@ -1,0 +1,169 @@
+//! SPI pin implementations
+
+use super::pads::{ad::*, sd::*};
+use crate::{
+    consts::*,
+    spi::{Pin, PCS0, SCK, SDI, SDO},
+    Daisy,
+};
+
+//
+// SPI1
+//
+
+// PCS0
+
+impl Pin for AD_05 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPSPI1_PCS_0_AD_05;
+    type Signal = PCS0;
+    type Module = U1;
+}
+
+impl Pin for SD_07 {
+    const ALT: u32 = 2;
+    const DAISY: Daisy = DAISY_LPSPI1_PCS_0_SD_07;
+    type Signal = PCS0;
+    type Module = U1;
+}
+
+// SCK
+
+impl Pin for AD_06 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPSPI1_SCK_AD_06;
+    type Signal = SCK;
+    type Module = U1;
+}
+
+impl Pin for SD_08 {
+    const ALT: u32 = 2;
+    const DAISY: Daisy = DAISY_LPSPI1_SCK_SD_08;
+    type Signal = SCK;
+    type Module = U1;
+}
+
+// SDI
+
+impl Pin for AD_03 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPSPI1_SDI_AD_03;
+    type Signal = SDI;
+    type Module = U1;
+}
+
+impl Pin for SD_05 {
+    const ALT: u32 = 2;
+    const DAISY: Daisy = DAISY_LPSPI1_SDI_SD_05;
+    type Signal = SDI;
+    type Module = U1;
+}
+
+// SDO
+
+impl Pin for AD_04 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPSPI1_SDO_AD_04;
+    type Signal = SDO;
+    type Module = U1;
+}
+
+impl Pin for SD_06 {
+    const ALT: u32 = 2;
+    const DAISY: Daisy = DAISY_LPSPI1_SDO_SD_06;
+    type Signal = SDO;
+    type Module = U1;
+}
+
+//
+// SPI2
+//
+
+// PCS0
+
+impl Pin for AD_11 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPSPI2_PCS_0_AD_11;
+    type Signal = PCS0;
+    type Module = U2;
+}
+
+impl Pin for SD_12 {
+    const ALT: u32 = 1;
+    const DAISY: Daisy = DAISY_LPSPI2_PCS_0_SD_12;
+    type Signal = PCS0;
+    type Module = U2;
+}
+
+// SCK
+
+impl Pin for AD_12 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPSPI2_SCK_AD_12;
+    type Signal = SCK;
+    type Module = U2;
+}
+
+impl Pin for SD_11 {
+    const ALT: u32 = 1;
+    const DAISY: Daisy = DAISY_LPSPI2_SCK_SD_11;
+    type Signal = SCK;
+    type Module = U2;
+}
+
+// SDI
+
+impl Pin for AD_09 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPSPI2_SDI_AD_09;
+    type Signal = SDI;
+    type Module = U2;
+}
+
+impl Pin for SD_09 {
+    const ALT: u32 = 1;
+    const DAISY: Daisy = DAISY_LPSPI2_SDI_SD_09;
+    type Signal = SDI;
+    type Module = U2;
+}
+
+// SDO
+
+impl Pin for AD_10 {
+    const ALT: u32 = 0;
+    const DAISY: Daisy = DAISY_LPSPI2_SDO_AD_10;
+    type Signal = SDO;
+    type Module = U2;
+}
+
+impl Pin for SD_10 {
+    const ALT: u32 = 1;
+    const DAISY: Daisy = DAISY_LPSPI2_SDO_SD_10;
+    type Signal = SDO;
+    type Module = U2;
+}
+
+mod daisy {
+    #![allow(unused)]
+
+    use super::Daisy;
+
+    pub const DAISY_LPSPI1_PCS_0_AD_05: Daisy = Daisy::new(0x401f81d0 as *mut u32, 0);
+    pub const DAISY_LPSPI1_PCS_0_SD_07: Daisy = Daisy::new(0x401f81d0 as *mut u32, 1);
+    pub const DAISY_LPSPI1_SCK_AD_06: Daisy = Daisy::new(0x401f81d4 as *mut u32, 0);
+    pub const DAISY_LPSPI1_SCK_SD_08: Daisy = Daisy::new(0x401f81d4 as *mut u32, 1);
+    pub const DAISY_LPSPI1_SDI_AD_03: Daisy = Daisy::new(0x401f81d8 as *mut u32, 0);
+    pub const DAISY_LPSPI1_SDI_SD_05: Daisy = Daisy::new(0x401f81d8 as *mut u32, 1);
+    pub const DAISY_LPSPI1_SDO_AD_04: Daisy = Daisy::new(0x401f81dc as *mut u32, 0);
+    pub const DAISY_LPSPI1_SDO_SD_06: Daisy = Daisy::new(0x401f81dc as *mut u32, 1);
+    pub const DAISY_LPSPI2_PCS_0_AD_11: Daisy = Daisy::new(0x401f81e0 as *mut u32, 0);
+    pub const DAISY_LPSPI2_PCS_0_SD_12: Daisy = Daisy::new(0x401f81e0 as *mut u32, 1);
+    pub const DAISY_LPSPI2_SCK_AD_12: Daisy = Daisy::new(0x401f81e4 as *mut u32, 0);
+    pub const DAISY_LPSPI2_SCK_SD_11: Daisy = Daisy::new(0x401f81e4 as *mut u32, 1);
+    pub const DAISY_LPSPI2_SDI_AD_09: Daisy = Daisy::new(0x401f81e8 as *mut u32, 0);
+    pub const DAISY_LPSPI2_SDI_SD_09: Daisy = Daisy::new(0x401f81e8 as *mut u32, 1);
+    pub const DAISY_LPSPI2_SDO_AD_10: Daisy = Daisy::new(0x401f81ec as *mut u32, 0);
+    pub const DAISY_LPSPI2_SDO_SD_10: Daisy = Daisy::new(0x401f81ec as *mut u32, 1);
+}
+
+use daisy::*;


### PR DESCRIPTION
The PR adds I2C and SPI `imxrt-iomuxc` trait implementations for the 1011 pads.

Part of #87.