### PR TITLE
Add SpiBus, SpiDevice implementations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,6 +118,24 @@ jobs:
     - name: Run unit, integration tests
       run: cargo test --features=${{ matrix.chips }} --tests --package=imxrt-hal --package=imxrt-log
 
+  # Make sure our unit tests can pass (some recent version of) miri.
+  miri:
+    needs: tests
+    strategy:
+      matrix:
+        chips:
+        - imxrt-ral/imxrt1011,imxrt1010
+        - imxrt-ral/imxrt1021,imxrt1020
+        - imxrt-ral/imxrt1062,imxrt1060
+        - imxrt-ral/imxrt1176_cm7,imxrt1170
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install a nightly toolchain with miri
+      run: rustup toolchain install nightly --no-self-update --profile minimal --component miri
+    - name: Run unit, integration tests with miri
+      run: cargo +nightly miri test --features=${{ matrix.chips }} --tests --package=imxrt-hal --package=imxrt-log --config "profile.dev.opt-level = 0"
+
   # Ensures that documentation builds, and that links are valid
   docs:
     needs: format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - There is no more `PCS0` type state associated with the LPSPI bus.
 
 Introduce a hardware chip select and SPI mode into each LPSPI transaction.
+Add an LPSPI configuration for hardware chip selects.
 
 ## [0.5.9] 2024-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
 - `timer::*PitChan`
 - `lpspi::Disabled::{set_mode, set_watermark}`
 
-**BREAKING** `LpspiError::{Busy, NoData}` are removed as possible LPSPI errors.
+**BREAKING** Change the LPSPI driver:
+
+- `LpspiError::{Busy, NoData}` are removed as possible LPSPI errors.
+- There is no more `PCS0` type state associated with the LPSPI bus.
 
 ## [0.5.9] 2024-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - `LpspiError::{Busy, NoData}` are removed as possible LPSPI errors.
 - There is no more `PCS0` type state associated with the LPSPI bus.
 
+Introduce a hardware chip select into each LPSPI transaction.
+
 ## [0.5.9] 2024-11-24
 
 Correct LPSPI receive operations. Previously, `u8` and `u16` elements received

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `LpspiError::{Busy, NoData}` are removed as possible LPSPI errors.
 - There is no more `PCS0` type state associated with the LPSPI bus.
 
-Introduce a hardware chip select into each LPSPI transaction.
+Introduce a hardware chip select and SPI mode into each LPSPI transaction.
 
 ## [0.5.9] 2024-11-24
 

--- a/board/Cargo.toml
+++ b/board/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 [dependencies.defmt]
 version = "0.3"
 
+[dependencies.eh1]
+package = "embedded-hal"
+version = "1.0"
+
 [dependencies.imxrt-hal]
 workspace = true
 

--- a/board/src/imxrt1010evk.rs
+++ b/board/src/imxrt1010evk.rs
@@ -64,8 +64,10 @@ pub type SpiPins = hal::lpspi::Pins<
     iomuxc::gpio_ad::GPIO_AD_04, // SDO, J57_8
     iomuxc::gpio_ad::GPIO_AD_03, // SDI, J57_10
     iomuxc::gpio_ad::GPIO_AD_06, // SCK, J57_12
-    iomuxc::gpio_ad::GPIO_AD_05, // PCS0, J57_6
 >;
+
+/// SPI PCS0 (J57_6).
+pub type SpiPcs0 = iomuxc::gpio_ad::GPIO_AD_05;
 
 #[cfg(feature = "spi")]
 pub type Spi = hal::lpspi::Lpspi<SpiPins, 1>;
@@ -192,8 +194,11 @@ impl Specifics {
                 sdo: iomuxc.gpio_ad.p04,
                 sdi: iomuxc.gpio_ad.p03,
                 sck: iomuxc.gpio_ad.p06,
-                pcs0: iomuxc.gpio_ad.p05,
             };
+            crate::iomuxc::lpspi::prepare({
+                let pcs0: &mut SpiPcs0 = &mut iomuxc.gpio_ad.p05;
+                pcs0
+            });
             let mut spi = Spi::new(lpspi1, pins);
             spi.disabled(|spi| {
                 spi.set_clock_hz(super::LPSPI_CLK_FREQUENCY, super::SPI_BAUD_RATE_FREQUENCY);

--- a/board/src/imxrt1060evk.rs
+++ b/board/src/imxrt1060evk.rs
@@ -62,8 +62,9 @@ pub type SpiPins = hal::lpspi::Pins<
     iomuxc::gpio_sd_b0::GPIO_SD_B0_02, // SDO, J24_4
     iomuxc::gpio_sd_b0::GPIO_SD_B0_03, // SDI, J24_5
     iomuxc::gpio_sd_b0::GPIO_SD_B0_00, // SCK, J24_6
-    iomuxc::gpio_sd_b0::GPIO_SD_B0_01, // PCS0, J24_3
 >;
+/// SPI PCS0 (J24_3).
+pub type SpiPcs0 = iomuxc::gpio_sd_b0::GPIO_SD_B0_01;
 
 #[cfg(not(feature = "spi"))]
 /// Activate the `"spi"` feature to configure the SPI peripheral.
@@ -180,8 +181,11 @@ impl Specifics {
                 sdo: iomuxc.gpio_sd_b0.p02,
                 sdi: iomuxc.gpio_sd_b0.p03,
                 sck: iomuxc.gpio_sd_b0.p00,
-                pcs0: iomuxc.gpio_sd_b0.p01,
             };
+            crate::iomuxc::lpspi::prepare({
+                let pcs0: &mut SpiPcs0 = &mut iomuxc.gpio_sd_b0.p01;
+                pcs0
+            });
             let mut spi = Spi::new(lpspi1, pins);
             spi.disabled(|spi| {
                 spi.set_clock_hz(super::LPSPI_CLK_FREQUENCY, super::SPI_BAUD_RATE_FREQUENCY);

--- a/board/src/imxrt1170evk-cm7.rs
+++ b/board/src/imxrt1170evk-cm7.rs
@@ -92,8 +92,9 @@ pub type SpiPins = hal::lpspi::Pins<
     iomuxc::gpio_ad::GPIO_AD_30, // SDO, J10_8
     iomuxc::gpio_ad::GPIO_AD_31, // SDI, J10_10
     iomuxc::gpio_ad::GPIO_AD_28, // SCK, J10_12
-    iomuxc::gpio_ad::GPIO_AD_29, // PCS0, J10_6
 >;
+/// SPI PCS0 (J10_6).
+pub type SpiPcs0 = iomuxc::gpio_ad::GPIO_AD_29;
 const SPI_INSTANCE: u8 = 1;
 
 #[cfg(feature = "spi")]
@@ -207,8 +208,11 @@ impl Specifics {
                 sdo: iomuxc.gpio_ad.p30,
                 sdi: iomuxc.gpio_ad.p31,
                 sck: iomuxc.gpio_ad.p28,
-                pcs0: iomuxc.gpio_ad.p29,
             };
+            crate::iomuxc::lpspi::prepare({
+                let pcs0: &mut SpiPcs0 = &mut iomuxc.gpio_ad.p29;
+                pcs0
+            });
             let mut spi = Spi::new(lpspi1, pins);
             spi.disabled(|spi| {
                 spi.set_clock_hz(LPSPI_CLK_FREQUENCY, super::SPI_BAUD_RATE_FREQUENCY);

--- a/board/src/lib.rs
+++ b/board/src/lib.rs
@@ -282,6 +282,20 @@ pub mod blocking {
     }
 }
 
+pub struct PanickingDelay(());
+
+impl PanickingDelay {
+    pub fn new() -> Self {
+        Self(())
+    }
+}
+
+impl eh1::delay::DelayNs for PanickingDelay {
+    fn delay_ns(&mut self, _: u32) {
+        unimplemented!()
+    }
+}
+
 /// Configurations for the logger.
 ///
 /// If your board is ready to support the logging infrastructure,

--- a/board/src/teensy4.rs
+++ b/board/src/teensy4.rs
@@ -49,8 +49,10 @@ pub type SpiPins = hal::lpspi::Pins<
     iomuxc::gpio_b0::GPIO_B0_02, // SDO, P11
     iomuxc::gpio_b0::GPIO_B0_01, // SDI, P12
     iomuxc::gpio_b0::GPIO_B0_03, // SCK, P13
-    iomuxc::gpio_b0::GPIO_B0_00, // PCS0, P10
 >;
+
+/// SPI PCS0 (P10).
+pub type SpiPcs0 = iomuxc::gpio_b0::GPIO_B0_00;
 
 #[cfg(not(feature = "spi"))]
 /// Activate the `"spi"` feature to configure the SPI peripheral.
@@ -152,8 +154,11 @@ impl Specifics {
                 sdo: iomuxc.gpio_b0.p02,
                 sdi: iomuxc.gpio_b0.p01,
                 sck: iomuxc.gpio_b0.p03,
-                pcs0: iomuxc.gpio_b0.p00,
             };
+            crate::iomuxc::lpspi::prepare({
+                let pcs0: &mut SpiPcs0 = &mut iomuxc.gpio_b0.p00;
+                pcs0
+            });
             let mut spi = Spi::new(lpspi4, pins);
             spi.disabled(|spi| {
                 spi.set_clock_hz(super::LPSPI_CLK_FREQUENCY, super::SPI_BAUD_RATE_FREQUENCY);

--- a/src/chip/dma.rs
+++ b/src/chip/dma.rs
@@ -196,10 +196,9 @@ impl<P, const N: u8> lpspi::Lpspi<P, N> {
         channel: &'a mut Channel,
         buffer: &'a [u32],
     ) -> Result<peripheral::Write<'a, Self, u32>, lpspi::LpspiError> {
-        let mut transaction = lpspi::Transaction::new_u32s(buffer)?;
-        transaction.bit_order = self.bit_order();
-
+        let mut transaction = self.bus_transaction(buffer)?;
         transaction.receive_data_mask = true;
+
         self.wait_for_transmit_fifo_space()?;
         self.enqueue_transaction(&transaction);
         Ok(peripheral::write(channel, buffer, self))
@@ -216,10 +215,9 @@ impl<P, const N: u8> lpspi::Lpspi<P, N> {
         channel: &'a mut Channel,
         buffer: &'a mut [u32],
     ) -> Result<peripheral::Read<'a, Self, u32>, lpspi::LpspiError> {
-        let mut transaction = lpspi::Transaction::new_u32s(buffer)?;
-        transaction.bit_order = self.bit_order();
-
+        let mut transaction = self.bus_transaction(buffer)?;
         transaction.transmit_data_mask = true;
+
         self.wait_for_transmit_fifo_space()?;
         self.enqueue_transaction(&transaction);
         Ok(peripheral::read(channel, self, buffer))
@@ -238,8 +236,7 @@ impl<P, const N: u8> lpspi::Lpspi<P, N> {
         tx: &'a mut Channel,
         buffer: &'a mut [u32],
     ) -> Result<peripheral::FullDuplex<'a, Self, u32>, lpspi::LpspiError> {
-        let mut transaction = lpspi::Transaction::new_u32s(buffer)?;
-        transaction.bit_order = self.bit_order();
+        let transaction = self.bus_transaction(buffer)?;
 
         self.wait_for_transmit_fifo_space()?;
         self.enqueue_transaction(&transaction);

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -48,7 +48,6 @@
 //!     sdo: pads.gpio_b0.p02,
 //!     sdi: pads.gpio_b0.p01,
 //!     sck: pads.gpio_b0.p03,
-//!     pcs0: pads.gpio_b0.p00,
 //! };
 //!
 //! let mut spi4 = unsafe { LPSPI4::instance() };
@@ -399,13 +398,12 @@ pub struct Lpspi<P, const N: u8> {
 ///     GPIO_B0_02,
 ///     GPIO_B0_01,
 ///     GPIO_B0_03,
-///     GPIO_B0_00,
 /// >;
 ///
 /// // Helper type for your SPI peripheral
 /// type Lpspi<const N: u8> = hal::lpspi::Lpspi<LpspiPins, N>;
 /// ```
-pub struct Pins<SDO, SDI, SCK, PCS0> {
+pub struct Pins<SDO, SDI, SCK> {
     /// Serial data out
     ///
     /// Data travels from the SPI host controller to the SPI device.
@@ -416,29 +414,23 @@ pub struct Pins<SDO, SDI, SCK, PCS0> {
     pub sdi: SDI,
     /// Serial clock
     pub sck: SCK,
-    /// Chip select 0
-    ///
-    /// (PCSx) convention matches the hardware.
-    pub pcs0: PCS0,
 }
 
-impl<SDO, SDI, SCK, PCS0, const N: u8> Lpspi<Pins<SDO, SDI, SCK, PCS0>, N>
+impl<SDO, SDI, SCK, const N: u8> Lpspi<Pins<SDO, SDI, SCK>, N>
 where
     SDO: lpspi::Pin<Module = consts::Const<N>, Signal = lpspi::Sdo>,
     SDI: lpspi::Pin<Module = consts::Const<N>, Signal = lpspi::Sdi>,
     SCK: lpspi::Pin<Module = consts::Const<N>, Signal = lpspi::Sck>,
-    PCS0: lpspi::Pin<Module = consts::Const<N>, Signal = lpspi::Pcs0>,
 {
     /// Create a new LPSPI driver from the RAL LPSPI instance and a set of pins.
     ///
     /// When this call returns, the LPSPI pins are configured for their function.
     /// The peripheral is enabled after reset. The LPSPI clock speed is unspecified.
     /// The mode is [`MODE_0`]. The sample point is [`SamplePoint::DelayedEdge`].
-    pub fn new(lpspi: ral::lpspi::Instance<N>, mut pins: Pins<SDO, SDI, SCK, PCS0>) -> Self {
+    pub fn new(lpspi: ral::lpspi::Instance<N>, mut pins: Pins<SDO, SDI, SCK>) -> Self {
         lpspi::prepare(&mut pins.sdo);
         lpspi::prepare(&mut pins.sdi);
         lpspi::prepare(&mut pins.sck);
-        lpspi::prepare(&mut pins.pcs0);
         Self::init(lpspi, pins)
     }
 }

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -1518,6 +1518,15 @@ where
     }
 }
 
+/// Transmits dummy values.
+struct TransmitDummies;
+
+impl TransmitData for TransmitDummies {
+    fn next_word(&mut self, _: BitOrder) -> u32 {
+        u32::MAX
+    }
+}
+
 /// Receive data into a buffer.
 struct ReceiveBuffer<'a, W> {
     /// The write position.
@@ -1580,6 +1589,13 @@ where
         let valid_bytes = self.array_len().min(size_of_val(&word));
         W::unpack_word(word, bit_order, valid_bytes, |elem| self.next_write(elem));
     }
+}
+
+/// Receive dummy data.
+struct ReceiveDummies;
+
+impl ReceiveData for ReceiveDummies {
+    fn next_word(&mut self, _: u32) {}
 }
 
 /// Computes how may Ws fit inside a LPSPI word.

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -806,8 +806,7 @@ impl<P, const N: u8> Lpspi<P, N> {
             return Ok(());
         }
 
-        let mut transaction = Transaction::new_words(data)?;
-        transaction.bit_order = self.bit_order();
+        let transaction = self.bus_transaction(data)?;
 
         self.wait_for_transmit_fifo_space()?;
         self.enqueue_transaction(&transaction);
@@ -831,9 +830,8 @@ impl<P, const N: u8> Lpspi<P, N> {
             return Ok(());
         }
 
-        let mut transaction = Transaction::new_words(data)?;
+        let mut transaction = self.bus_transaction(data)?;
         transaction.receive_data_mask = true;
-        transaction.bit_order = self.bit_order();
 
         self.wait_for_transmit_fifo_space()?;
         self.enqueue_transaction(&transaction);
@@ -987,6 +985,13 @@ impl<P, const N: u8> Lpspi<P, N> {
             dbt: dbt as u8,
             sckdiv: sckdiv as u8,
         }
+    }
+
+    /// Produce a transaction that considers bus-managed software state.
+    pub(crate) fn bus_transaction<W>(&self, words: &[W]) -> Result<Transaction, LpspiError> {
+        let mut transaction = Transaction::new_words(words)?;
+        transaction.bit_order = self.bit_order();
+        Ok(transaction)
     }
 }
 

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -133,6 +133,25 @@ pub enum LpspiError {
     Fifo(Direction),
 }
 
+/// Peripheral chip select.
+///
+/// Use this in [`Transaction`] to select the hardware-managed
+/// chip select. Note that the hardware only uses the hardware-managed
+/// chip select if the pin is muxed for its PCS alternate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u32)]
+pub enum Pcs {
+    /// Use PCS0 (default) for the next transaction.
+    #[default]
+    Pcs0,
+    /// Use PCS1 for the next transaction.
+    Pcs1,
+    /// Use PCS2 for the next transaction.
+    Pcs2,
+    /// Use PCS3 for the next transaction.
+    Pcs3,
+}
+
 /// An LPSPI transaction definition.
 ///
 /// The transaction defines how many bits the driver sends or recieves.
@@ -142,6 +161,7 @@ pub enum LpspiError {
 /// - bit order
 /// - transmit and receive masking
 /// - continuous and continuing transfers (default: both disabled)
+/// - the hardware-managed peripheral chip select, [`Pcs`]
 ///
 /// The LPSPI enqueues the transaction data into the transmit
 /// FIFO. When it pops the values from the FIFO, the values take
@@ -241,7 +261,10 @@ pub struct Transaction {
     /// `Transaction`, one that had [`continuous`](Self::continuous) set.
     /// The default value is `false`.
     pub continuing: bool,
-
+    /// Selects the hardware-managed peripheral chip select for the transaction.
+    ///
+    /// See [`Pcs`] for more information.
+    pub pcs: Pcs,
     frame_size: u16,
 }
 
@@ -300,6 +323,7 @@ impl Transaction {
                 frame_size: frame_size - 1,
                 continuing: false,
                 continuous: false,
+                pcs: Default::default(),
             })
         } else {
             Err(LpspiError::FrameSize)
@@ -741,7 +765,8 @@ impl<P, const N: u8> Lpspi<P, N> {
             TXMSK: transaction.transmit_data_mask as u32,
             FRAMESZ: transaction.frame_size as u32,
             CONT: transaction.continuous as u32,
-            CONTC: transaction.continuing as u32
+            CONTC: transaction.continuing as u32,
+            PCS: transaction.pcs as u32
         );
     }
 


### PR DESCRIPTION
We implement all I/O in terms of `transact`. We'll manually flush at the
end of eh02 SPI writes. Since the `SpiBus` interface exposes a flush, we
have no need to perform an internal flush when transacting I/O.

Keep the spinning async state machines to manage the TX and FX FIFOs.
We introduce a schedule to eagerly execute transmit operations ahead of
receive operations. Without this ability, we'll stall the LPSPI bus.
(The NOSTALL field can change this behavior, but then we move complexity
into TX FIFO underrun handling.) There's some miri tests to simulate our
hardware utilization.

Our `SpiDevice` impls mimic the embedded-bus design. There's an
"exclusive" device that owns the bus and uses a hardware chip select.
There's a `RefCellDevice` that lets users share the bus and use hardware
chip selects. There's no critical section / mutex device, but it should
be straightforward to add that later.

Part of #142.