### PR TITLE
Fix the fix for PIT lifetime value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+Fix how the PIT driver corrects the lifetime value.
+
 ## [0.5.13] 2026-03-15
 
 Add OCOTP driver for reading and writing fuses.

--- a/src/common/pit.rs
+++ b/src/common/pit.rs
@@ -316,7 +316,7 @@ impl Chained<0, 1> {
         let mut high = self.low.instance.LTMR64H.read();
         let mut low = self.low.instance.LTMR64L.read();
 
-        let ldval0 = self.low.load_timer_value();
+        let ldval0 = self.low.instance.TIMER[0].LDVAL.read();
         if low == ldval0 {
             high = self.low.instance.LTMR64H.read();
             low = self.low.instance.LTMR64L.read();


### PR DESCRIPTION
The public API call increments the LDVAL by one, ensuring that the user sees the value representing their desired ticks. However, that off-by-one isn't appropriate for fixing the lifetime value; it'll never compare.

Observed during the 0.6 driver refactor. That refactor includes this fix.