### PR TITLE
Add weekly linting job, bump actions/checkout version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install a stable toolchain with rustfmt
       run: rustup toolchain install stable --no-self-update --profile minimal --component rustfmt
     - name: Check formatting
@@ -37,7 +37,7 @@ jobs:
         - imxrt-ral/imxrt1189_cm7,imxrt1180
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install a stable toolchain with clippy
       run: rustup toolchain install stable --no-self-update --profile minimal --component clippy
     - name: Lint imxrt-hal
@@ -61,7 +61,7 @@ jobs:
         - imxrt-ral/imxrt1176_cm7,imxrt1170
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install a stable toolchain with clippy
       run: rustup toolchain install stable --no-self-update --profile minimal --component clippy
     - name: Lint imxrt-log
@@ -75,7 +75,7 @@ jobs:
         backend: [lpuart, usbd]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install a stable toolchain with clippy
       run: rustup toolchain install stable --no-self-update --profile minimal --component clippy
     - name: Lint imxrt-log with ${{ matrix.backend }} backend only
@@ -113,7 +113,7 @@ jobs:
           --example=rtic_defmt_rtt        
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install a stable toolchain, clippy, for the MCU target
       run: rustup toolchain install stable --no-self-update --profile minimal --component clippy --target thumbv7em-none-eabihf
     - name: Lint board and examples
@@ -126,7 +126,7 @@ jobs:
     needs: lint-hal
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install a stable toolchain for the MCU target
       run: rustup toolchain install stable --no-self-update --profile minimal --target thumbv8m.main-none-eabihf
     - name: Build examples
@@ -152,7 +152,7 @@ jobs:
         - imxrt-ral/imxrt1176_cm7,imxrt1170
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install a stable toolchain
       run: rustup toolchain install stable --no-self-update --profile minimal
     - name: Run unit, integration tests
@@ -170,7 +170,7 @@ jobs:
         - imxrt-ral/imxrt1176_cm7,imxrt1170
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install a nightly toolchain with miri
       run: rustup toolchain install nightly --no-self-update --profile minimal --component miri
     - name: Run unit, integration tests with miri
@@ -183,7 +183,7 @@ jobs:
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install a stable toolchain
       run: rustup toolchain install stable --no-self-update --profile minimal
     - name: Run documentation tests

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,55 @@
+# Try to catch toolchain changes before they appear
+# in unrelated work.
+name: Weekly lints
+
+on:
+  workflow_dispatch:
+  schedule:
+  # Rust releases occur on Thursdays. Try to
+  # ping me around 7AM my time, every Thursday.
+  - cron: '0 11 * * THU'
+
+jobs:
+  # Lint the workspace through the board packages.
+  #
+  # Covers imxrt-hal, imxrt-log, and board. Excludes
+  # examples and tests.
+  lint-board:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+        - stable
+        - beta
+        - nightly
+        board:
+        - teensy4
+        - imxrt1010evk
+        - imxrt1170evk-cm7
+        - imxrt1060evk
+    steps:
+    - uses: actions/checkout@v6
+    - run: rustup toolchain install ${{ matrix.toolchain }} --no-self-update --profile minimal --component clippy --target thumbv7em-none-eabihf
+    - run: cargo +${{ matrix.toolchain }} --version
+    - run: cargo +${{ matrix.toolchain }} clippy --workspace --features=board/${{ matrix.board }} --target=thumbv7em-none-eabihf -- -D warnings
+
+  # Lint the workspace to cover chips that don't have a board.
+  #
+  # Covers only imxrt-hal and imxrt-log. No tests.
+  lint-rest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+        - stable
+        - beta
+        - nightly
+        chip:
+        - imxrt-ral/imxrt1021,imxrt1020
+    steps:
+    - uses: actions/checkout@v6
+    - run: rustup toolchain install ${{ matrix.toolchain }} --no-self-update --profile minimal --component clippy --target thumbv7em-none-eabihf
+    - run: cargo +${{ matrix.toolchain }} --version
+    - run: cargo +${{ matrix.toolchain }} clippy --package=imxrt-hal --package=imxrt-log --features=${{ matrix.chip }} --target=thumbv7em-none-eabihf -- -D warnings


### PR DESCRIPTION
I've used the weekly jobs as a way to keep ahead of clippy warnings (as opposed to pinning a toolchain). Contributing them upstream means I don't have to keep my fork's `main` branch up to date, and it gives others a chance to help out.

There were warnings about deprecated Node.js versions in our `actions/checkout` version. I'm bumping that too.