### PR TITLE
Fix doc test of logging package

### DIFF
--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -137,7 +137,7 @@
 //! an interrupt-driven USB logger. It uses `imxrt-hal` APIs to prepare the logger.
 //!
 //! ```no_run
-//! use imxrt_log::defmt; // <-- Change 'defmt' to 'log' to change the frontend.
+//! use imxrt_log::defmt as frontend; // <-- Change 'defmt' to 'log' to change the frontend.
 //! use imxrt_hal as hal;
 //! use imxrt_ral as ral;
 //!
@@ -167,7 +167,7 @@
 //!         usbphy: unsafe { ral::usbphy::USBPHY1::instance() },
 //!     };
 //!     // Initialize the logger, and ensure that it triggers interrupts.
-//!     let poller = defmt::usbd(usb_instances, imxrt_log::Interrupts::Enabled).ok()?;
+//!     let poller = frontend::usbd(usb_instances, imxrt_log::Interrupts::Enabled).ok()?;
 //!     Some(poller)
 //! }
 //!


### PR DESCRIPTION
Seems like the `defmt::log!` expansion is now searching for an `export` module inside our defmt module, not the defmt package. Not sure what's changed here. Rename our defmt module to avoid the ambiguity.