### PR TITLE
Fix linker flag breaking ELF entry point

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,5 @@ rustflags = [
     "-C", "link-arg=-Timxrt-link.x",
     "-C", "link-arg=-Tdefmt.x",
     "-C", "link-arg=-Tdevice.x",
-    "-C", "link-arg=-error-limit=0",
     "-C", "link-arg=-nmagic",
 ]


### PR DESCRIPTION
`-error-limit=0` has a single dash, so LLD parses it as `-e rror-limit=0`. Symbol `rror-limit=0` doesn't exist, so it falls back to `e_entry = 0x0`.

Boards here are unaffected since the i.MX RT boot ROM starts from the vector table and never reads e_entry. Discovered this on the Coral Dev Board Micro, whose loader calls it.

```
cargo build --features=board/teensy4 --example hal_led --target=thumbv7em-none-eabihf
readelf -h target/thumbv7em-none-eabihf/debug/examples/hal_led | grep Entry

# before: Entry point address: 0x0
# after:  Entry point address: 0x60001031   (== `nm ... | grep ' Reset$'`)
```